### PR TITLE
SDLCOM-2750: MT Cloud 4.2.8.0: QE scores and Studio batch tasks

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/MetadataTransferObject.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/MetadataTransferObject.cs
@@ -7,6 +7,6 @@ namespace Sdl.Community.MTCloud.Provider.Model
 	{
 		public string FilePath { get; set; }
 		public List<SegmentId> SegmentIds { get; set; }
-		public TranslationOriginInformation TranslationOriginInformation { get; set; }
+		public TranslationOriginData TranslationOriginData{ get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/QualityEstimation.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/QualityEstimation.cs
@@ -36,9 +36,9 @@ namespace Sdl.Community.MTCloud.Provider.Model
 
 		private Dictionary<string, int> Qualifiers { get; } = new()
 		{
-			["GOOD"] = 0,
-			["ADEQUATE"] = 1,
-			["POOR"] = 2
+			["Good"] = 0,
+			["Adequate"] = 1,
+			["Poor"] = 2
 		};
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TargetSegmentData.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TargetSegmentData.cs
@@ -3,6 +3,6 @@
 	public class TargetSegmentData
 	{
 		public ImprovementFeedback Feedback { get; set; }
-		public TranslationOriginInformation TranslationOriginInformation { get; set; }
+		public TranslationOriginDatum TranslationOriginDatum { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationData.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationData.cs
@@ -10,7 +10,7 @@ namespace Sdl.Community.MTCloud.Provider.Model
 		public List<string> SourceSegments { get; set; }
 		public string TargetLanguage { get; set; }
 		public List<string> TargetSegments { get; set; }
+		public TranslationOriginData TranslationOriginData{ get; set; }
 
-		public TranslationOriginInformation TranslationOriginInformation { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationOriginData.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationOriginData.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Sdl.FileTypeSupport.Framework.NativeApi;
+
+namespace Sdl.Community.MTCloud.Provider.Model
+{
+	public class TranslationOriginData
+	{
+		public string Model { get; set; }
+		public Dictionary<SegmentId, string> QualityEstimations { get; set; }
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationOriginDatum.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationOriginDatum.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sdl.Community.MTCloud.Provider.Model
 {
-	public class TranslationOriginInformation
+	public class TranslationOriginDatum
 	{
 		public string Model { get; set; }
 		public string QualityEstimation { get; set; }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationResponseStatus.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/TranslationResponseStatus.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Http;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Sdl.Community.MTCloud.Provider.Model
 {
@@ -10,9 +9,6 @@ namespace Sdl.Community.MTCloud.Provider.Model
 
 		[JsonProperty("outputFormat")]
 		public string OutputFormat { get; set; }
-
-		[JsonProperty("qualityEstimation")]
-		public string[] QualityEstimation { get; set; }
 
 		[JsonProperty("translationStats")]
 		public TranslationResponseStats TranslationStats { get; set; }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
@@ -207,7 +207,8 @@
     <Compile Include="Model\TargetSegmentData.cs" />
     <Compile Include="Model\TranslationData.cs" />
     <Compile Include="Model\TranslationFeedbackRequest.cs" />
-    <Compile Include="Model\TranslationOriginInformation.cs" />
+    <Compile Include="Model\TranslationOriginData.cs" />
+    <Compile Include="Model\TranslationOriginDatum.cs" />
     <Compile Include="Model\TranslationRequest.cs" />
     <Compile Include="Model\TranslationResponse.cs" />
     <Compile Include="Model\TranslationResponseStats.cs" />

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/IMetadataSupervisor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/IMetadataSupervisor.cs
@@ -2,7 +2,7 @@
 
 namespace Sdl.Community.MTCloud.Provider.Service.Interface
 {
-	public interface IMetadataSupervisor : ISupervisor<TranslationOriginInformation>
+	public interface IMetadataSupervisor : ISupervisor<TranslationOriginDatum>
 	{
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/ISegmentMetadataCreator.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/Interface/ISegmentMetadataCreator.cs
@@ -7,7 +7,7 @@ namespace Sdl.Community.MTCloud.Provider.Service.Interface
 	{
 		void AddTargetSegmentMetaData(TranslationData translationData);
 
-		void AddToCurrentSegmentContextData(IStudioDocument activeDocument, TranslationOriginInformation translationOriginInformation);
+		void AddToCurrentSegmentContextData(IStudioDocument activeDocument, TranslationOriginDatum translationOriginDatum);
 
 		void AddToSegmentContextData();
 	}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetaDataProcessor.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/MetaDataProcessor.cs
@@ -37,15 +37,17 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			foreach (var datum in TranslationData)
 			{
 				if (segmentPairsRemaining == 0) break;
-				var metaData = datum.TranslationOriginInformation;
+				var metaData = datum.TranslationOriginData;
 				var segmentPairs = GetValidSegmentPairs(paragraphUnit, datum.SegmentIds);
 
 				foreach (var segmentPair in segmentPairs)
 				{
 					segmentPairsRemaining--;
-					var translationOrigin = segmentPair.Properties.TranslationOrigin;
 
-					translationOrigin.SetMetaData("quality_estimation", metaData.QualityEstimation);
+					var segmentPairProperties = segmentPair.Properties;
+					var translationOrigin = segmentPairProperties.TranslationOrigin;
+
+					translationOrigin.SetMetaData("quality_estimation", metaData.QualityEstimations[segmentPairProperties.Id]);
 					translationOrigin.SetMetaData("model", metaData.Model);
 				}
 				_usedIds.AddRange(segmentPairs.Select(sp => sp.Properties.Id));

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentMetadataCreator.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/SegmentMetadataCreator.cs
@@ -30,7 +30,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			Data.Add(translationData);
 		}
 
-		public void AddToCurrentSegmentContextData(IStudioDocument activeDocument, TranslationOriginInformation translationOriginInformation)
+		public void AddToCurrentSegmentContextData(IStudioDocument activeDocument, TranslationOriginDatum translationOriginDatum)
 		{
 			var currentSegmentPair = activeDocument.ActiveSegmentPair;
 			var translationOrigin = currentSegmentPair.Properties.TranslationOrigin;
@@ -38,8 +38,8 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			if (translationOrigin is null)
 				return;
 
-			translationOrigin.SetMetaData("quality_estimation", translationOriginInformation.QualityEstimation);
-			translationOrigin.SetMetaData("model", translationOriginInformation.Model);
+			translationOrigin.SetMetaData("quality_estimation", translationOriginDatum.QualityEstimation);
+			translationOrigin.SetMetaData("model", translationOriginDatum.Model);
 
 			activeDocument.UpdateSegmentPairProperties(currentSegmentPair, currentSegmentPair.Properties);
 		}
@@ -63,7 +63,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		{
 			FilePath = GetFilePath(translationData),
 			SegmentIds = translationData.Segments.Keys.ToList(),
-			TranslationOriginInformation = translationData.TranslationOriginInformation
+			TranslationOriginData = translationData.TranslationOriginData
 		};
 
 		private string GetFilePath(TranslationData translationData)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
@@ -144,7 +144,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 			if (response is null) return null;
 
-			var (responseMessage, qualityEstimation) = await CheckTranslationStatus(translationResponse?.RequestId);
+			var responseMessage = await CheckTranslationStatus(translationResponse?.RequestId);
 			var translations = await _httpClient.GetResult<TranslationResponse>(responseMessage);
 
 			var translation = translations?.Translation?.FirstOrDefault();
@@ -154,27 +154,24 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			if (translatedXliff == null) return null;
 
 			var targetSegments = translatedXliff.GetTargetSegments();
+			var segments = fileAndSegments.Segments;
+			var segmentIds = fileAndSegments.Segments.Keys.ToList();
 
 			OnTranslationReceived(new TranslationData
 			{
-				SourceSegments = fileAndSegments.Segments.Values.ToList(),
-				TargetSegments = targetSegments.Select(seg => seg.ToString()).ToList(),
-				TranslationOriginInformation = new TranslationOriginInformation
-				{
+				SourceSegments = segments.Values.ToList(),
+				TargetSegments = targetSegments.Select(seg => seg.Segment.ToString()).ToList(),
+				TranslationOriginData = new TranslationOriginData{
 					Model = translations.Model,
-					QualityEstimation = qualityEstimation
+					QualityEstimations = segmentIds.Select((k, i) => new { k, v = targetSegments[i].QualityEstimation })
+						.ToDictionary(x => x.k, x => x.v)
 				},
 				FilePath = fileAndSegments.FilePath,
 				Segments = fileAndSegments.Segments,
 				TargetLanguage = model.TargetTradosCode
 			});
 
-			return targetSegments;
-		}
-
-		private static string GetQualityEstimation(TranslationResponseStatus responseStatus)
-		{
-			return responseStatus.QualityEstimation?[0];
+			return targetSegments.Select(seg => seg.Segment).ToArray();
 		}
 
 		private static void WaitForTranslation(TranslationResponseStatus responseStatus)
@@ -199,10 +196,9 @@ namespace Sdl.Community.MTCloud.Provider.Service
 			throw new Exception(PluginResources.Message_Connection_token_has_expired);
 		}
 
-		private async Task<(HttpResponseMessage, string)> CheckTranslationStatus(string id)
+		private async Task<HttpResponseMessage> CheckTranslationStatus(string id)
 		{
 			var translationStatus = string.Empty;
-			string qualityEstimation = null;
 
 			do
 			{
@@ -217,8 +213,6 @@ namespace Sdl.Community.MTCloud.Provider.Service
 				WaitForTranslation(responseStatus);
 
 				translationStatus = responseStatus.TranslationStatus;
-				qualityEstimation = GetQualityEstimation(responseStatus);
-
 				if (translationStatus.ToUpperInvariant() != Constants.FAILED) continue;
 
 				var response = await _httpClient.GetResult<ResponseError>(responseMessage);
@@ -236,7 +230,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 				}
 			} while (translationStatus.ToUpperInvariant() == Constants.INIT || translationStatus.ToUpperInvariant() == Constants.TRANSLATING);
 
-			return (await GetTranslationResult(id), qualityEstimation);
+			return await GetTranslationResult(id);
 		}
 
 		private dynamic CreateFeedbackRequest(FeedbackInfo feedbackInfo)

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/SdlMTCloudLanguageDirection.cs
@@ -410,7 +410,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio
 		}
 
 		private bool IsDraftOrTranslated(ISegmentPair segmentPair)
-																																	=> segmentPair.Target?.Count > 0 || segmentPair.Properties.IsLocked;
+			=> segmentPair.Target?.Count > 0 || segmentPair.Properties.IsLocked;
 
 		private bool IsTargetEqualToSource(ISegmentPair segmentPair)
 			=> segmentPair.Source.ToString().Equals(segmentPair.Target.ToString());

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Converter/Xliff.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Converter/Xliff.cs
@@ -46,9 +46,9 @@ namespace Sdl.Community.MTCloud.Provider.XliffConverter.Converter
 			File?.Body?.Add(sourceSegment, targetSegment, toolId);
 		}
 
-		public Segment[] GetTargetSegments()
+		public List<EvaluatedSegment> GetTargetSegments()
 		{
-			var segments = new List<Segment>();
+			var segments = new List<EvaluatedSegment>();
 			foreach (var tu in File.Body.TranslationUnits)
 			{
 				var option = tu.TranslationList?.FirstOrDefault();
@@ -60,15 +60,25 @@ namespace Sdl.Community.MTCloud.Provider.XliffConverter.Converter
 				}
 
 				segment.Culture = File.TargetCulture ?? File.SourceCulture;
-				segments.Add(segment);
+				segments.Add(new EvaluatedSegment
+				{
+					Segment = segment,
+					QualityEstimation = option.MatchQuality
+				});
 			}
 
-			return segments.ToArray();
+			return segments;
 		}
 
 		public override string ToString()
 		{
 			return Converter.PrintXliff(this);
 		}
+	}
+
+	public class EvaluatedSegment
+	{
+		public Segment Segment { get; set; }
+		public string QualityEstimation { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Models/TranslationOption.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/XliffConverter/Models/TranslationOption.cs
@@ -12,5 +12,8 @@ namespace Sdl.Community.MTCloud.Provider.XliffConverter.Models
 
 		[XmlElement("target")]
 		public TargetTranslation Translation { get; set; }
+		
+		[XmlAttribute("match-quality")]
+		public string MatchQuality { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>SDL Machine Translation Cloud</PlugInName>
-	<Version>4.2.7.0</Version>
+	<Version>4.2.8.0</Version>
 	<Description>SDL Machine Translation Cloud provider</Description>
 	<Author>SDL Community Developers</Author>
 	<Include>


### PR DESCRIPTION
MT Cloud's API for how we receive the QEs changed -> we now receive QE for each segment directly in the XLIFF as a new xml element