### PR TITLE
SDLCOM-2905: Target Renamer - remaining issues

### DIFF
--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
@@ -47,12 +47,6 @@ namespace Trados.TargetRenamer.BatchTask
 			set => GetSetting<string>(nameof(Delimiter)).Value = value;
 		}
 
-		public bool OverwriteTargetFiles
-		{
-			get => GetSetting<bool>(nameof(OverwriteTargetFiles));
-			set => GetSetting<bool>(nameof(OverwriteTargetFiles)).Value = value;
-		}
-
 		public string RegularExpressionReplaceWith
 		{
 			get => GetSetting<string>(nameof(RegularExpressionReplaceWith));

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
@@ -1,4 +1,5 @@
-﻿using Sdl.Core.Settings;
+﻿using System.ComponentModel;
+using Sdl.Core.Settings;
 using Trados.TargetRenamer.Interfaces;
 
 namespace Trados.TargetRenamer.BatchTask

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettings.cs
@@ -1,81 +1,80 @@
-﻿using System.ComponentModel;
-using Sdl.Core.Settings;
+﻿using Sdl.Core.Settings;
 using Trados.TargetRenamer.Interfaces;
 
 namespace Trados.TargetRenamer.BatchTask
 {
 	public class TargetRenamerSettings : SettingsGroup, ITargetRenamerSettings
-	{
-		public bool AppendAsPrefix
-		{
-			get => GetSetting<bool>(nameof(AppendAsPrefix));
-			set => GetSetting<bool>(nameof(AppendAsPrefix)).Value = value;
-		}
+    {
+        public bool AppendAsPrefix
+        {
+            get => GetSetting<bool>(nameof(AppendAsPrefix));
+            set => GetSetting<bool>(nameof(AppendAsPrefix)).Value = value;
+        }
 
-		public bool AppendAsSuffix
-		{
-			get => GetSetting<bool>(nameof(AppendAsSuffix));
-			set => GetSetting<bool>(nameof(AppendAsSuffix)).Value = value;
-		}
+        public bool AppendAsSuffix
+        {
+            get => GetSetting<bool>(nameof(AppendAsSuffix));
+            set => GetSetting<bool>(nameof(AppendAsSuffix)).Value = value;
+        }
 
-		public bool AppendCustomString
-		{
-			get => GetSetting<bool>(nameof(AppendCustomString));
-			set => GetSetting<bool>(nameof(AppendCustomString)).Value = value;
-		}
+        public bool AppendCustomString
+        {
+            get => GetSetting<bool>(nameof(AppendCustomString));
+            set => GetSetting<bool>(nameof(AppendCustomString)).Value = value;
+        }
 
-		public bool AppendTargetLanguage
-		{
-			get => GetSetting<bool>(nameof(AppendTargetLanguage));
-			set => GetSetting<bool>(nameof(AppendTargetLanguage)).Value = value;
-		}
+        public bool AppendTargetLanguage
+        {
+            get => GetSetting<bool>(nameof(AppendTargetLanguage));
+            set => GetSetting<bool>(nameof(AppendTargetLanguage)).Value = value;
+        }
 
-		public string CustomLocation
-		{
-			get => GetSetting<string>(nameof(CustomLocation));
-			set => GetSetting<string>(nameof(CustomLocation)).Value = value;
-		}
+        public string CustomLocation
+        {
+            get => GetSetting<string>(nameof(CustomLocation));
+            set => GetSetting<string>(nameof(CustomLocation)).Value = value;
+        }
 
-		public string CustomString
-		{
-			get => GetSetting<string>(nameof(CustomString));
-			set => GetSetting<string>(nameof(CustomString)).Value = value;
-		}
+        public string CustomString
+        {
+            get => GetSetting<string>(nameof(CustomString));
+            set => GetSetting<string>(nameof(CustomString)).Value = value;
+        }
 
-		public string Delimiter
-		{
-			get => GetSetting<string>(nameof(Delimiter));
-			set => GetSetting<string>(nameof(Delimiter)).Value = value;
-		}
+        public string Delimiter
+        {
+            get => GetSetting<string>(nameof(Delimiter));
+            set => GetSetting<string>(nameof(Delimiter)).Value = value;
+        }
 
-		public string RegularExpressionReplaceWith
-		{
-			get => GetSetting<string>(nameof(RegularExpressionReplaceWith));
-			set => GetSetting<string>(nameof(RegularExpressionReplaceWith)).Value = value;
-		}
+        public string RegularExpressionReplaceWith
+        {
+            get => GetSetting<string>(nameof(RegularExpressionReplaceWith));
+            set => GetSetting<string>(nameof(RegularExpressionReplaceWith)).Value = value;
+        }
 
-		public string RegularExpressionSearchFor
-		{
-			get => GetSetting<string>(nameof(RegularExpressionSearchFor));
-			set => GetSetting<string>(nameof(RegularExpressionSearchFor)).Value = value;
-		}
+        public string RegularExpressionSearchFor
+        {
+            get => GetSetting<string>(nameof(RegularExpressionSearchFor));
+            set => GetSetting<string>(nameof(RegularExpressionSearchFor)).Value = value;
+        }
 
-		public bool UseCustomLocation
-		{
-			get => GetSetting<bool>(nameof(UseCustomLocation));
-			set => GetSetting<bool>(nameof(UseCustomLocation)).Value = value;
-		}
+        public bool UseCustomLocation
+        {
+            get => GetSetting<bool>(nameof(UseCustomLocation));
+            set => GetSetting<bool>(nameof(UseCustomLocation)).Value = value;
+        }
 
-		public bool UseRegularExpression
-		{
-			get => GetSetting<bool>(nameof(UseRegularExpression));
-			set => GetSetting<bool>(nameof(UseRegularExpression)).Value = value;
-		}
+        public bool UseRegularExpression
+        {
+            get => GetSetting<bool>(nameof(UseRegularExpression));
+            set => GetSetting<bool>(nameof(UseRegularExpression)).Value = value;
+        }
 
-		public bool UseShortLocales
-		{
-			get => GetSetting<bool>(nameof(UseShortLocales));
-			set => GetSetting<bool>(nameof(UseShortLocales)).Value = value;
-		}
-	}
+        public bool UseShortLocales
+        {
+            get => GetSetting<bool>(nameof(UseShortLocales));
+            set => GetSetting<bool>(nameof(UseShortLocales)).Value = value;
+        }
+    }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettingsPage.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettingsPage.cs
@@ -5,44 +5,44 @@ using Trados.TargetRenamer.Control;
 namespace Trados.TargetRenamer.BatchTask
 {
 	public class TargetRenamerSettingsPage : DefaultSettingsPage<TargetRenamerSettingsControl, TargetRenamerSettings>
-	{
-		private TargetRenamerSettingsControl _control;
-		private TargetRenamerSettings _settings;
+    {
+        private TargetRenamerSettingsControl _control;
+        private TargetRenamerSettings _settings;
 
-		public override object GetControl()
-		{
-			_settings = ((ISettingsBundle)DataSource).GetSettingsGroup<TargetRenamerSettings>();
-			_control = base.GetControl() as TargetRenamerSettingsControl;
-			if (!(_control is null))
-			{
-				_control.TargetRenamerSettingsViewModel.Settings = _settings;
-			}
+        public override object GetControl()
+        {
+            _settings = ((ISettingsBundle)DataSource).GetSettingsGroup<TargetRenamerSettings>();
+            _control = base.GetControl() as TargetRenamerSettingsControl;
+            if (!(_control is null))
+            {
+                _control.TargetRenamerSettingsViewModel.Settings = _settings;
+            }
 
-			return _control;
-		}
+            return _control;
+        }
 
-		public override void Save()
-		{
-			base.Save();
-			if (_settings is null) return;
-			_settings.AppendAsPrefix = _control.TargetRenamerSettingsViewModel.AppendAsPrefix;
-			_settings.AppendAsSuffix = _control.TargetRenamerSettingsViewModel.AppendAsSuffix;
-			_settings.UseRegularExpression = _control.TargetRenamerSettingsViewModel.UseRegularExpression;
-			_settings.UseCustomLocation = _control.TargetRenamerSettingsViewModel.UseCustomLocation;
-			_settings.CustomLocation = _control.TargetRenamerSettingsViewModel.CustomLocation;
-			_settings.RegularExpressionSearchFor = _control.TargetRenamerSettingsViewModel.RegularExpressionSearchFor;
-			_settings.RegularExpressionReplaceWith =
-				_control.TargetRenamerSettingsViewModel.RegularExpressionReplaceWith;
-			_settings.Delimiter = _control.TargetRenamerSettingsViewModel.Delimiter;
-			_settings.UseShortLocales = _control.TargetRenamerSettingsViewModel.UseShortLocales;
-			_settings.AppendTargetLanguage = _control.TargetRenamerSettingsViewModel.AppendTargetLanguage;
-			_settings.AppendCustomString = _control.TargetRenamerSettingsViewModel.AppendCustomString;
-			_settings.CustomString = _control.TargetRenamerSettingsViewModel.CustomString;
-		}
+        public override void Save()
+        {
+            base.Save();
+            if (_settings is null) return;
+            _settings.AppendAsPrefix = _control.TargetRenamerSettingsViewModel.AppendAsPrefix;
+            _settings.AppendAsSuffix = _control.TargetRenamerSettingsViewModel.AppendAsSuffix;
+            _settings.UseRegularExpression = _control.TargetRenamerSettingsViewModel.UseRegularExpression;
+            _settings.UseCustomLocation = _control.TargetRenamerSettingsViewModel.UseCustomLocation;
+            _settings.CustomLocation = _control.TargetRenamerSettingsViewModel.CustomLocation;
+            _settings.RegularExpressionSearchFor = _control.TargetRenamerSettingsViewModel.RegularExpressionSearchFor;
+            _settings.RegularExpressionReplaceWith =
+                _control.TargetRenamerSettingsViewModel.RegularExpressionReplaceWith;
+            _settings.Delimiter = _control.TargetRenamerSettingsViewModel.Delimiter;
+            _settings.UseShortLocales = _control.TargetRenamerSettingsViewModel.UseShortLocales;
+            _settings.AppendTargetLanguage = _control.TargetRenamerSettingsViewModel.AppendTargetLanguage;
+            _settings.AppendCustomString = _control.TargetRenamerSettingsViewModel.AppendCustomString;
+            _settings.CustomString = _control.TargetRenamerSettingsViewModel.CustomString;
+        }
 
-		public override bool ValidateInput()
-		{
-			return !_control.TargetRenamerSettingsViewModel.HasErrors;
-		}
-	}
+        public override bool ValidateInput()
+        {
+            return !_control.TargetRenamerSettingsViewModel.HasErrors;
+        }
+    }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettingsPage.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/BatchTask/TargetRenamerSettingsPage.cs
@@ -25,7 +25,6 @@ namespace Trados.TargetRenamer.BatchTask
 		{
 			base.Save();
 			if (_settings is null) return;
-			_settings.OverwriteTargetFiles = _control.TargetRenamerSettingsViewModel.OverwriteTargetFiles;
 			_settings.AppendAsPrefix = _control.TargetRenamerSettingsViewModel.AppendAsPrefix;
 			_settings.AppendAsSuffix = _control.TargetRenamerSettingsViewModel.AppendAsSuffix;
 			_settings.UseRegularExpression = _control.TargetRenamerSettingsViewModel.UseRegularExpression;

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.Designer.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.Designer.cs
@@ -33,10 +33,11 @@ namespace Trados.TargetRenamer.Control
 		{
             this.targetRenamerHost = new System.Windows.Forms.Integration.ElementHost();
             this.SuspendLayout();
-            // 
-            // targetRenamerHost
-            // 
-            this.targetRenamerHost.Location = new System.Drawing.Point(0, 0);
+			// 
+			// targetRenamerHost
+			// 
+			this.targetRenamerHost.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.targetRenamerHost.Location = new System.Drawing.Point(0, 0);
             this.targetRenamerHost.Name = "targetRenamerHost";
             this.targetRenamerHost.Size = new System.Drawing.Size(800, 450);
             this.targetRenamerHost.TabIndex = 0;

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using Sdl.Desktop.IntegrationApi;
-using Sdl.Desktop.IntegrationApi.Interfaces;
 using Trados.TargetRenamer.BatchTask;
 using Trados.TargetRenamer.Interfaces;
 using Trados.TargetRenamer.Services;
@@ -19,6 +10,7 @@ namespace Trados.TargetRenamer.Control
 	public partial class TargetRenamerSettingsControl : UserControl, ISettingsAware<TargetRenamerSettings>
 	{
 		private readonly IFolderDialogService _folderDialogService;
+
 		public TargetRenamerSettingsControl()
 		{
 			InitializeComponent();

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Control/TargetRenamerSettingsControl.cs
@@ -32,8 +32,7 @@ namespace Trados.TargetRenamer.Control
 			targetRenamerHost.Child = targetRenamerSettingsControl;
 		}
 
-		public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel { get; set; }
-
 		public TargetRenamerSettings Settings { get; set; }
+		public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel { get; set; }
 	}
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Helpers/FileNameValidationRule.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Helpers/FileNameValidationRule.cs
@@ -10,15 +10,15 @@ namespace Trados.TargetRenamer.Helpers
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             var text = string.Empty;
-			try
-			{
-                if (((string) value).Length > 0)
+            try
+            {
+                if (((string)value).Length > 0)
                 {
                     text = value.ToString();
                 }
             }
             catch (Exception)
-			{
+            {
                 return new ValidationResult(false, PluginResources.SelectionEmpty);
             }
 

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Helpers/PathValidationRule.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Helpers/PathValidationRule.cs
@@ -11,36 +11,36 @@ namespace Trados.TargetRenamer.Helpers
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             var path = string.Empty;
-			try
-			{
+            try
+            {
                 if (((string)value).Length > 0)
                 {
                     path = value.ToString();
                 }
             }
             catch (Exception)
-			{
+            {
                 return new ValidationResult(false, PluginResources.EmptyPath);
             }
 
-			try
-			{
-				Path.GetDirectoryName(path);
-			}
+            try
+            {
+                Path.GetDirectoryName(path);
+            }
             catch (Exception)
-			{
+            {
                 return new ValidationResult(false, PluginResources.InvalidPath);
             }
 
-	        var folderPathRegEx =
-		        new Regex(@"^(([a-zA-Z]:)|(\\{2}\w+)\$?)(\\(\w[\w ]*))+\\?");
+            var folderPathRegEx =
+                new Regex(@"^(([a-zA-Z]:)|(\\{2}\w+)\$?)(\\(\w[\w ]*))+\\?");
 
-			var match = folderPathRegEx.Match(path);
+            var match = folderPathRegEx.Match(path);
 
-	        if (!match.Success || match.Length < path.Length)
-		        return new ValidationResult(false, PluginResources.InvalidPathChars);
+            if (!match.Success || match.Length < path.Length)
+                return new ValidationResult(false, PluginResources.InvalidPathChars);
 
-	        return ValidationResult.ValidResult;
+            return ValidationResult.ValidResult;
         }
     }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Interfaces/ITargetRenamerSettings.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Interfaces/ITargetRenamerSettings.cs
@@ -9,7 +9,6 @@
         string CustomLocation { get; set; }
         string CustomString { get; set; }
         string Delimiter { get; set; }
-        bool OverwriteTargetFiles { get; set; }
         string RegularExpressionReplaceWith { get; set; }
         string RegularExpressionSearchFor { get; set; }
         bool UseCustomLocation { get; set; }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Services/ReportCreatorService.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/Services/ReportCreatorService.cs
@@ -121,7 +121,6 @@ namespace Trados.TargetRenamer.Services
         private static void WriteReportSettingsInfo(string location, XmlWriter writer, TargetRenamerSettings settings)
         {
             writer.WriteStartElement("settings");
-            writer.WriteAttributeString("overwriteTargetFiles", settings.OverwriteTargetFiles.ToString());
             writer.WriteAttributeString("path", location);
             writer.WriteAttributeString("delimiter", settings.Delimiter);
             writer.WriteAttributeString("targetLanguage", settings.AppendTargetLanguage.ToString());

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TargetRenamer.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TargetRenamer.cs
@@ -14,156 +14,169 @@ using Trados.TargetRenamer.Services;
 namespace Trados.TargetRenamer
 {
 	[AutomaticTask("Target Renamer",
-		"TargetRenamer_Name",
-		"TargetRenamer_Description",
-		GeneratedFileType = AutomaticTaskFileType.BilingualTarget)]
-	[AutomaticTaskSupportedFileType(AutomaticTaskFileType.BilingualTarget)]
-	[RequiresSettings(typeof(TargetRenamerSettings), typeof(TargetRenamerSettingsPage))]
-	public class TargetRenamer : AbstractFileContentProcessingAutomaticTask
-	{
-		private readonly Logger _logger = LogManager.GetCurrentClassLogger();
-		private List<ProjectFile> _projectFiles;
-		private Dictionary<(ProjectFile, LanguageDirection), Tuple<string, string>> _renamedFiles;
-		private ReportCreatorService _reportCreator;
-		private TargetRenamerSettings _settings;
+        "TargetRenamer_Name",
+        "TargetRenamer_Description",
+        GeneratedFileType = AutomaticTaskFileType.BilingualTarget)]
+    [AutomaticTaskSupportedFileType(AutomaticTaskFileType.BilingualTarget)]
+    [RequiresSettings(typeof(TargetRenamerSettings), typeof(TargetRenamerSettingsPage))]
+    public class TargetRenamer : AbstractFileContentProcessingAutomaticTask
+    {
+        private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private List<ProjectFile> _projectFiles;
+        private Dictionary<(ProjectFile, LanguageDirection), Tuple<string, string>> _renamedFiles;
+        private ReportCreatorService _reportCreator;
+        private TargetRenamerSettings _settings;
 
-		public override void TaskComplete()
+        public override void TaskComplete()
+        {
+            base.TaskComplete();
+            GenerateReports();
+        }
+
+        protected override void ConfigureConverter(ProjectFile projectFile, IMultiFileConverter multiFileConverter)
+        {
+            _projectFiles.Add(projectFile);
+            _settings = Project.GetSettings(projectFile.Language).GetSettingsGroup<TargetRenamerSettings>();
+
+            var fileIds = new List<Guid>() { projectFile.Id };
+            var task = Project.RunAutomaticTask(fileIds.ToArray(), AutomaticTaskTemplateIds.GenerateTargetTranslations);
+            if (task == null || task.Status != TaskStatus.Completed)
+                _logger.Error($"{task?.Messages?.FirstOrDefault()?.Message}\n The task has not been run correctly.");
+
+            var targetLanguage = new CultureInfo(projectFile.GetLanguageDirection().TargetLanguage.IsoAbbreviation);
+            var files = Project.GetTargetLanguageFiles(projectFile.GetLanguageDirection().TargetLanguage);
+            var file = files.SingleOrDefault(x => x.SourceFile.Id.Equals(projectFile.SourceFile.Id));
+            var filePath = Path.GetDirectoryName(file.LocalFilePath);
+            var fileExtension = Path.GetExtension(file.LocalFilePath);
+            var fileName = Path.GetFileNameWithoutExtension(file.LocalFilePath);
+            var oldFileName = Path.GetFileName(file.LocalFilePath);
+            if (_settings.AppendAsPrefix) fileName = CreateFileNameWithPrefix(fileName, fileExtension, targetLanguage);
+
+            if (_settings.AppendAsSuffix) fileName = CreateFileNameWithSuffix(fileName, fileExtension, targetLanguage);
+
+            if (_settings.UseRegularExpression)
+                fileName = CreateFileNameWithRegularExpression(fileName, fileExtension);
+
+            try
+            {
+                string newFileName;
+                if (_settings.UseCustomLocation)
+                {
+                    if (!Directory.Exists(_settings.CustomLocation))
+                        Directory.CreateDirectory(_settings.CustomLocation ??
+                                                  throw new InvalidOperationException("Invalid file path!"));
+                    newFileName = Path.Combine(_settings.CustomLocation, targetLanguage.Name, projectFile.Folder, fileName);
+                }
+                else
+                {
+                    newFileName = Path.Combine(filePath, fileName);
+                }
+
+                _renamedFiles.Add(
+                (projectFile, projectFile.GetLanguageDirection()),
+                new Tuple<string, string>(oldFileName, fileName));
+
+                // Ensure that the file does not exist
+                if (File.Exists(newFileName))
+                {
+                    File.Delete(newFileName);
+                }
+
+                Directory.CreateDirectory(Path.Combine(_settings.CustomLocation, targetLanguage.Name,
+                        projectFile.Folder));
+
+                File.Move(file.LocalFilePath, newFileName);
+            }
+            catch (Exception e)
+            {
+                _logger.Error($"{e.Message}\n {e.StackTrace}");
+            }
+
+			RevertToSdlXliff(projectFile);
+        }
+
+        protected override void OnInitializeTask()
+        {
+            Log.Setup();
+            _reportCreator = new ReportCreatorService();
+            _projectFiles = new List<ProjectFile>();
+            _renamedFiles = new Dictionary<(ProjectFile, LanguageDirection), Tuple<string, string>>();
+            base.OnInitializeTask();
+        }
+
+        private string CreateFileNameWithPrefix(string newFileName, string fileExtension, CultureInfo targetLanguage)
+        {
+            if (_settings.AppendTargetLanguage)
+            {
+                if (_settings.UseShortLocales)
+                    newFileName = targetLanguage.TwoLetterISOLanguageName + _settings.Delimiter + newFileName +
+                                  fileExtension;
+                else
+                    newFileName = targetLanguage.Name + _settings.Delimiter + newFileName + fileExtension;
+            }
+            else if (_settings.AppendCustomString)
+            {
+                newFileName = _settings.CustomString + _settings.Delimiter + newFileName + fileExtension;
+            }
+
+            return newFileName;
+        }
+
+        private string CreateFileNameWithRegularExpression(string newFileName, string fileExtension)
+        {
+            // Maybe add an option to IgnoreCase?
+            var newName = Regex.Replace(newFileName, _settings.RegularExpressionSearchFor,
+                _settings.RegularExpressionReplaceWith) + fileExtension;
+            return newName;
+        }
+
+        private string CreateFileNameWithSuffix(string newFileName, string fileExtension, CultureInfo targetLanguage)
+        {
+            if (_settings.AppendTargetLanguage)
+            {
+                if (_settings.UseShortLocales)
+                    newFileName = newFileName + _settings.Delimiter + targetLanguage.TwoLetterISOLanguageName + fileExtension;
+                else
+                    newFileName = newFileName + _settings.Delimiter + targetLanguage.Name + fileExtension;
+            }
+            else if (_settings.AppendCustomString)
+            {
+                newFileName = newFileName + _settings.Delimiter + _settings.CustomString + fileExtension;
+            }
+
+            return newFileName;
+        }
+
+        private void GenerateReports()
+        {
+            var languageDirections = _projectFiles
+                .GroupBy(p => new { p.GetLanguageDirection().TargetLanguage, p.GetLanguageDirection().SourceLanguage })
+                .Select(g => g.First().GetLanguageDirection());
+
+            foreach (var languageDirection in languageDirections)
+            {
+                _settings = Project.GetSettings(languageDirection.TargetLanguage).GetSettingsGroup<TargetRenamerSettings>();
+                var reportName =
+                    $"{PluginResources.TargetRenamer_Name}_{languageDirection.SourceLanguage.IsoAbbreviation}_{languageDirection.TargetLanguage.IsoAbbreviation}";
+
+                var projectFiles = _projectFiles
+                    .Where(x => Equals(x.GetLanguageDirection().TargetLanguage, languageDirection.TargetLanguage)).ToList();
+                _reportCreator.CreateReport(Project, projectFiles, _renamedFiles, _settings, languageDirection);
+
+                CreateReport(reportName, PluginResources.ReportDescription, _reportCreator.ReportFile, languageDirection);
+            }
+        }
+
+		private void RevertToSdlXliff(ProjectFile projectFile)
 		{
-			base.TaskComplete();
-			GenerateReports();
-		}
-
-		protected override void ConfigureConverter(ProjectFile projectFile, IMultiFileConverter multiFileConverter)
-		{
-			_projectFiles.Add(projectFile);
-			_settings = Project.GetSettings(projectFile.Language).GetSettingsGroup<TargetRenamerSettings>();
-
-			var fileIds = new List<Guid>() { projectFile.Id };
-			var task = Project.RunAutomaticTask(fileIds.ToArray(), AutomaticTaskTemplateIds.GenerateTargetTranslations);
-			if (task == null || task.Status != TaskStatus.Completed)
-				_logger.Error($"{task?.Messages?.FirstOrDefault()?.Message}\n The task has not been run correctly.");
-
-			var targetLanguage = new CultureInfo(projectFile.GetLanguageDirection().TargetLanguage.IsoAbbreviation);
-			var files = Project.GetTargetLanguageFiles(projectFile.GetLanguageDirection().TargetLanguage);
-			var file = files.SingleOrDefault(x => x.SourceFile.Id.Equals(projectFile.SourceFile.Id));
-			var filePath = Path.GetDirectoryName(file.LocalFilePath);
-			var fileExtension = Path.GetExtension(file.LocalFilePath);
-			var fileName = Path.GetFileNameWithoutExtension(file.LocalFilePath);
-			var oldFileName = Path.GetFileName(file.LocalFilePath);
-			if (_settings.AppendAsPrefix) fileName = CreateFileNameWithPrefix(fileName, fileExtension, targetLanguage);
-
-			if (_settings.AppendAsSuffix) fileName = CreateFileNameWithSuffix(fileName, fileExtension, targetLanguage);
-
-			if (_settings.UseRegularExpression)
-				fileName = CreateFileNameWithRegularExpression(fileName, fileExtension);
-
-			try
-			{
-				string newFileName;
-				if (_settings.UseCustomLocation)
-				{
-					if (!Directory.Exists(_settings.CustomLocation))
-						Directory.CreateDirectory(_settings.CustomLocation ??
-												  throw new InvalidOperationException("Invalid file path!"));
-					newFileName = Path.Combine(_settings.CustomLocation, targetLanguage.Name, projectFile.Folder, fileName);
-				}
-				else
-				{
-					newFileName = Path.Combine(filePath, fileName);
-				}
-
-				_renamedFiles.Add(
-				(projectFile, projectFile.GetLanguageDirection()),
-				new Tuple<string, string>(oldFileName, fileName));
-
-				// Ensure that the file does not exist
-				if (File.Exists(newFileName))
-				{
-					File.Delete(newFileName);
-				}
-
-				Directory.CreateDirectory(Path.Combine(_settings.CustomLocation, targetLanguage.Name,
-						projectFile.Folder));
-
-				File.Move(file.LocalFilePath, newFileName);
-			}
-			catch (Exception e)
-			{
-				_logger.Error($"{e.Message}\n {e.StackTrace}");
-			}
-
 			Project.AddNewFileVersion(projectFile.Id, projectFile.LocalFilePath);
-		}
+			var projectFileDirectory = Path.GetDirectoryName(projectFile.LocalFilePath);
+			if (projectFileDirectory == null) return;
 
-		protected override void OnInitializeTask()
-		{
-			Log.Setup();
-			_reportCreator = new ReportCreatorService();
-			_projectFiles = new List<ProjectFile>();
-			_renamedFiles = new Dictionary<(ProjectFile, LanguageDirection), Tuple<string, string>>();
-			base.OnInitializeTask();
-		}
-
-		private string CreateFileNameWithPrefix(string newFileName, string fileExtension, CultureInfo targetLanguage)
-		{
-			if (_settings.AppendTargetLanguage)
+			var latestFile = Directory.GetFiles(projectFileDirectory).ToList().OrderByDescending(File.GetCreationTime).FirstOrDefault();
+			if (string.IsNullOrWhiteSpace(Path.GetExtension(latestFile)) && Path.GetFileNameWithoutExtension(projectFile.Name) == Path.GetFileNameWithoutExtension(latestFile) && latestFile != null)
 			{
-				if (_settings.UseShortLocales)
-					newFileName = targetLanguage.TwoLetterISOLanguageName + _settings.Delimiter + newFileName +
-								  fileExtension;
-				else
-					newFileName = targetLanguage.Name + _settings.Delimiter + newFileName + fileExtension;
-			}
-			else if (_settings.AppendCustomString)
-			{
-				newFileName = _settings.CustomString + _settings.Delimiter + newFileName + fileExtension;
-			}
-
-			return newFileName;
-		}
-
-		private string CreateFileNameWithRegularExpression(string newFileName, string fileExtension)
-		{
-			// Maybe add an option to IgnoreCase?
-			var newName = Regex.Replace(newFileName, _settings.RegularExpressionSearchFor,
-				_settings.RegularExpressionReplaceWith) + fileExtension;
-			return newName;
-		}
-
-		private string CreateFileNameWithSuffix(string newFileName, string fileExtension, CultureInfo targetLanguage)
-		{
-			if (_settings.AppendTargetLanguage)
-			{
-				if (_settings.UseShortLocales)
-					newFileName = newFileName + _settings.Delimiter + targetLanguage.TwoLetterISOLanguageName + fileExtension;
-				else
-					newFileName = newFileName + _settings.Delimiter + targetLanguage.Name + fileExtension;
-			}
-			else if (_settings.AppendCustomString)
-			{
-				newFileName = newFileName + _settings.Delimiter + _settings.CustomString + fileExtension;
-			}
-
-			return newFileName;
-		}
-
-		private void GenerateReports()
-		{
-			var languageDirections = _projectFiles
-				.GroupBy(p => new { p.GetLanguageDirection().TargetLanguage, p.GetLanguageDirection().SourceLanguage })
-				.Select(g => g.First().GetLanguageDirection());
-
-			foreach (var languageDirection in languageDirections)
-			{
-				_settings = Project.GetSettings(languageDirection.TargetLanguage).GetSettingsGroup<TargetRenamerSettings>();
-				var reportName =
-					$"{PluginResources.TargetRenamer_Name}_{languageDirection.SourceLanguage.IsoAbbreviation}_{languageDirection.TargetLanguage.IsoAbbreviation}";
-
-				var projectFiles = _projectFiles
-					.Where(x => Equals(x.GetLanguageDirection().TargetLanguage, languageDirection.TargetLanguage)).ToList();
-				_reportCreator.CreateReport(Project, projectFiles, _renamedFiles, _settings, languageDirection);
-
-				CreateReport(reportName, PluginResources.ReportDescription, _reportCreator.ReportFile, languageDirection);
+				File.Delete(latestFile);
 			}
 		}
 	}

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TargetRenamer.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TargetRenamer.cs
@@ -73,26 +73,19 @@ namespace Trados.TargetRenamer
 				}
 
 				_renamedFiles.Add(
-					(projectFile, projectFile.GetLanguageDirection()),
-					new Tuple<string, string>(oldFileName, fileName));
+				(projectFile, projectFile.GetLanguageDirection()),
+				new Tuple<string, string>(oldFileName, fileName));
 
-				if (_settings.OverwriteTargetFiles)
+				// Ensure that the file does not exist
+				if (File.Exists(newFileName))
 				{
-					// Ensure that the file does not exist
-					if (File.Exists(newFileName))
-					{
-						File.Delete(newFileName);
-					}
-
-					Directory.CreateDirectory(Path.Combine(_settings.CustomLocation, targetLanguage.Name,
-							projectFile.Folder));
-
-					File.Move(file.LocalFilePath, newFileName);
+					File.Delete(newFileName);
 				}
-				else
-				{
-					File.Copy(file.LocalFilePath, newFileName);
-				}
+
+				Directory.CreateDirectory(Path.Combine(_settings.CustomLocation, targetLanguage.Name,
+						projectFile.Folder));
+
+				File.Move(file.LocalFilePath, newFileName);
 			}
 			catch (Exception e)
 			{

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TellMe/HelpAction.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TellMe/HelpAction.cs
@@ -5,21 +5,21 @@ using Sdl.TellMe.ProviderApi;
 namespace Trados.TargetRenamer.TellMe
 {
 	public class HelpAction : AbstractTellMeAction
-	{
-		public HelpAction()
-		{
-			Name = $"{PluginResources.TargetRenamer_Name} wiki in the RWS Community";
-		}
+    {
+        public HelpAction()
+        {
+            Name = $"{PluginResources.TargetRenamer_Name} wiki in the RWS Community";
+        }
 
-		public override string Category => $"{PluginResources.TargetRenamer_Name} results";
+        public override string Category => $"{PluginResources.TargetRenamer_Name} results";
 
-		public override Icon Icon => PluginResources.Question;
+        public override Icon Icon => PluginResources.Question;
 
-		public override bool IsAvailable => true;
+        public override bool IsAvailable => true;
 
-		public override void Execute()
-		{
-			Process.Start("https://community.sdl.com/product-groups/translationproductivity/w/customer-experience/5956/target-renamer");
-		}
-	}
+        public override void Execute()
+        {
+            Process.Start("https://community.sdl.com/product-groups/translationproductivity/w/customer-experience/5956/target-renamer");
+        }
+    }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TellMe/TellMeProvider.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/TellMe/TellMeProvider.cs
@@ -3,16 +3,16 @@
 namespace Trados.TargetRenamer.TellMe
 {
 	[TellMeProvider]
-	public class TellMeProvider : ITellMeProvider
-	{
-		public string Name => $"{PluginResources.TargetRenamer_Name} tell me provider";
+    public class TellMeProvider : ITellMeProvider
+    {
+        public string Name => $"{PluginResources.TargetRenamer_Name} tell me provider";
 
-		public AbstractTellMeAction[] ProviderActions => new AbstractTellMeAction[]
-		{
-				new HelpAction
-				{
-					Keywords = new []{ "trados target renamer", "help", "guide" }
-				},
-		};
-	}
+        public AbstractTellMeAction[] ProviderActions => new AbstractTellMeAction[]
+        {
+                new HelpAction
+                {
+                    Keywords = new []{ "trados target renamer", "help", "guide" }
+                },
+        };
+    }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
@@ -38,6 +38,7 @@
 		<TextBlock Text="Target Renamer"
 		           Style="{StaticResource Sdl.TextBlock.TitleStyle}"
 				   FontSize="15"
+				   TextWrapping="Wrap"
 		           DockPanel.Dock="Top" />
 		<TextBlock Text="Target Renamer is a batch tasks plugin that allows the user to save the target files with various options for custom naming."
 				   Margin="0 5 0 0"

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
@@ -134,6 +134,7 @@
 					       VerticalAlignment="Center"
 					       Visibility="{Binding UseRegularExpression, Converter={StaticResource BooleanToVisibilityConverter}}" />
 					<TextBox VerticalAlignment="Center"
+							 x:Name="RegexReplaceWith"
 					         HorizontalAlignment="Center"
 					         Width="Auto"
 					         MinWidth="200"
@@ -141,7 +142,7 @@
 					         Height="{Binding ActualHeight, ElementName=ComboBox}"
 					         Visibility="{Binding UseRegularExpression, Converter={StaticResource BooleanToVisibilityConverter}}">
 						<TextBox.Text>
-							<Binding Path="RegularExpressionReplaceWith" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay">
+							<Binding Path="RegularExpressionReplaceWith" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" NotifyOnValidationError="True">
 								<Binding.ValidationRules>
 									<helpers:FileNameValidationRule />
 								</Binding.ValidationRules>
@@ -187,7 +188,7 @@
 					</RadioButton.Visibility>
 				</RadioButton>
 				<TextBox Grid.Row="2" Grid.Column="1"
-				         x:Name="CustomStringTextBox"
+				         x:Name="CustomString"
 				         VerticalAlignment="Center"
 				         HorizontalAlignment="Left"
 				         Width="Auto"
@@ -196,7 +197,7 @@
 				         Height="{Binding ActualHeight, ElementName=ComboBox}"
 				         Visibility="{Binding AppendCustomString, Converter={StaticResource BooleanToVisibilityConverter}}">
 					<TextBox.Text>
-						<Binding Path="CustomString" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay">
+						<Binding Path="CustomString" UpdateSourceTrigger="PropertyChanged" Mode="TwoWay" NotifyOnValidationError="True">
 							<Binding.ValidationRules>
 								<helpers:FileNameValidationRule />
 							</Binding.ValidationRules>

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
@@ -51,23 +51,16 @@
 				<Grid.RowDefinitions>
 					<RowDefinition />
 					<RowDefinition />
-					<RowDefinition />
 				</Grid.RowDefinitions>
-				<CheckBox Grid.Row="0" Grid.Column="0"
-				          Width="Auto"
-				          Margin="5 10 5 10"
-				          Style="{StaticResource Sdl.Checkbox.GenericStyle}"
-				          Content="{x:Static resx:PluginResources.OverwriteTargetFiles}"
-				          ToolTip="{x:Static resx:PluginResources.OverwriteTargetFilesTooltip}"
-				          IsChecked="{Binding OverwriteTargetFiles, UpdateSourceTrigger=PropertyChanged}" />
+				
 
-				<CheckBox Grid.Row="1" Grid.Column="0"
+				<CheckBox Grid.Row="0" Grid.Column="0"
 				          Margin="5 5 0 5"
 				          Style="{StaticResource Sdl.Checkbox.GenericStyle}"
 				          Content="{x:Static resx:PluginResources.CustomLocation}"
 				          ToolTip="{x:Static resx:PluginResources.CustomLocationTooltip}"
 				          IsChecked="{Binding UseCustomLocation}" />
-				<WrapPanel Grid.Column="0" Grid.Row="2">
+				<WrapPanel Grid.Column="0" Grid.Row="1">
 					<TextBox Margin="5"
 							 Name="CustomLocation"
 					         VerticalAlignment="Center"

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml
@@ -53,7 +53,6 @@
 					<RowDefinition />
 					<RowDefinition />
 				</Grid.RowDefinitions>
-				
 
 				<CheckBox Grid.Row="0" Grid.Column="0"
 				          Margin="5 5 0 5"

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml.cs
@@ -9,46 +9,46 @@ namespace Trados.TargetRenamer.View
 	/// Interaction logic for TargetRenamerSettingsView.xaml
 	/// </summary>
 	public partial class TargetRenamerSettingsView : ISettingsAware<TargetRenamerSettings>
-	{
-		public TargetRenamerSettingsView()
-		{
-			InitializeComponent();
-			AddErrorHandlers();
-		}
+    {
+        public TargetRenamerSettingsView()
+        {
+            InitializeComponent();
+            AddErrorHandlers();
+        }
 
-		public TargetRenamerSettings Settings { get; set; }
-		public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel => (TargetRenamerSettingsViewModel)DataContext;
-		private bool CustomLocationHasErrors { get; set; }
-		private bool DelimiterHasErrors { get; set; }
+        public TargetRenamerSettings Settings { get; set; }
+        public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel => (TargetRenamerSettingsViewModel)DataContext;
+        private bool CustomLocationHasErrors { get; set; }
+        private bool DelimiterHasErrors { get; set; }
 
-		public void AddErrorHandlers()
-		{
-			Validation.AddErrorHandler(CustomLocation, ErrorHandler);
-			Validation.AddErrorHandler(Delimiter, ErrorHandler);
-		}
+        public void AddErrorHandlers()
+        {
+            Validation.AddErrorHandler(CustomLocation, ErrorHandler);
+            Validation.AddErrorHandler(Delimiter, ErrorHandler);
+        }
 
-		public void Dispose()
-		{
-		}
+        public void Dispose()
+        {
+        }
 
-		private void ErrorHandler(object sender, ValidationErrorEventArgs e)
-		{
-			var errorSource = e.OriginalSource as TextBox;
-			if (errorSource.Name == nameof(CustomLocation))
-			{
-				CustomLocationHasErrors = e.Action == ValidationErrorEventAction.Added;
-			}
-			if (errorSource.Name == nameof(Delimiter))
-			{
-				DelimiterHasErrors = e.Action == ValidationErrorEventAction.Added;
-			}
+        private void ErrorHandler(object sender, ValidationErrorEventArgs e)
+        {
+            var errorSource = e.OriginalSource as TextBox;
+            if (errorSource.Name == nameof(CustomLocation))
+            {
+                CustomLocationHasErrors = e.Action == ValidationErrorEventAction.Added;
+            }
+            if (errorSource.Name == nameof(Delimiter))
+            {
+                DelimiterHasErrors = e.Action == ValidationErrorEventAction.Added;
+            }
 
-			SetHasErrorOnViewModel();
-		}
+            SetHasErrorOnViewModel();
+        }
 
-		private void SetHasErrorOnViewModel()
-		{
-			TargetRenamerSettingsViewModel.HasErrors = CustomLocationHasErrors || DelimiterHasErrors;
-		}
-	}
+        private void SetHasErrorOnViewModel()
+        {
+            TargetRenamerSettingsViewModel.HasErrors = CustomLocationHasErrors || DelimiterHasErrors;
+        }
+    }
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/View/TargetRenamerSettingsView.xaml.cs
@@ -9,46 +9,62 @@ namespace Trados.TargetRenamer.View
 	/// Interaction logic for TargetRenamerSettingsView.xaml
 	/// </summary>
 	public partial class TargetRenamerSettingsView : ISettingsAware<TargetRenamerSettings>
-    {
-        public TargetRenamerSettingsView()
-        {
-            InitializeComponent();
-            AddErrorHandlers();
-        }
+	{
+		public TargetRenamerSettingsView()
+		{
+			InitializeComponent();
+			AddErrorHandlers();
+		}
 
-        public TargetRenamerSettings Settings { get; set; }
-        public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel => (TargetRenamerSettingsViewModel)DataContext;
-        private bool CustomLocationHasErrors { get; set; }
-        private bool DelimiterHasErrors { get; set; }
+		public TargetRenamerSettings Settings { get; set; }
+		public TargetRenamerSettingsViewModel TargetRenamerSettingsViewModel => (TargetRenamerSettingsViewModel)DataContext;
 
-        public void AddErrorHandlers()
-        {
-            Validation.AddErrorHandler(CustomLocation, ErrorHandler);
-            Validation.AddErrorHandler(Delimiter, ErrorHandler);
-        }
+		private bool CustomLocationHasErrors { get; set; }
+		private bool CustomStringHasErrors { get; set; }
+		private bool DelimiterHasErrors { get; set; }
+		private bool RegexReplaceWithHasErrors { get; set; }
 
-        public void Dispose()
-        {
-        }
+		public void AddErrorHandlers()
+		{
+			Validation.AddErrorHandler(CustomLocation, ErrorHandler);
+			Validation.AddErrorHandler(Delimiter, ErrorHandler);
+			Validation.AddErrorHandler(RegexReplaceWith, ErrorHandler);
+			Validation.AddErrorHandler(CustomString, ErrorHandler);
+		}
 
-        private void ErrorHandler(object sender, ValidationErrorEventArgs e)
-        {
-            var errorSource = e.OriginalSource as TextBox;
-            if (errorSource.Name == nameof(CustomLocation))
-            {
-                CustomLocationHasErrors = e.Action == ValidationErrorEventAction.Added;
-            }
-            if (errorSource.Name == nameof(Delimiter))
-            {
-                DelimiterHasErrors = e.Action == ValidationErrorEventAction.Added;
-            }
+		public void Dispose()
+		{
+		}
 
-            SetHasErrorOnViewModel();
-        }
+		private void ErrorHandler(object sender, ValidationErrorEventArgs e)
+		{
+			var errorSource = e.OriginalSource as TextBox;
 
-        private void SetHasErrorOnViewModel()
-        {
-            TargetRenamerSettingsViewModel.HasErrors = CustomLocationHasErrors || DelimiterHasErrors;
-        }
-    }
+			switch (errorSource?.Name)
+			{
+				case nameof(CustomLocation):
+					CustomLocationHasErrors = Validation.GetErrors(CustomLocation).Count > 0;
+					break;
+
+				case nameof(Delimiter):
+					DelimiterHasErrors = Validation.GetErrors(Delimiter).Count > 0;
+					break;
+
+				case nameof(RegexReplaceWith):
+					RegexReplaceWithHasErrors = Validation.GetErrors(RegexReplaceWith).Count > 0;
+					break;
+
+				case nameof(CustomString):
+					CustomStringHasErrors = Validation.GetErrors(CustomString).Count > 0;
+					break;
+			}
+
+			SetHasErrorOnViewModel();
+		}
+
+		private void SetHasErrorOnViewModel()
+		{
+			TargetRenamerSettingsViewModel.HasErrors = CustomLocationHasErrors || DelimiterHasErrors || RegexReplaceWithHasErrors || CustomStringHasErrors;
+		}
+	}
 }

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
@@ -36,7 +36,7 @@ namespace Trados.TargetRenamer.ViewModel
 		{
 			_folderDialogService = folderDialogService;
 			ComboBoxItems = new ObservableCollection<string> { AppendSuffixText, AppendPrefixText, RegExprText };
-			Reset(null);
+			//Reset(null);
 		}
 
 		public bool AppendAsPrefix
@@ -52,33 +52,33 @@ namespace Trados.TargetRenamer.ViewModel
 
 		public bool AppendAsSuffix
 		{
-			get => _appendAsSuffix;
+			get => Settings.AppendAsSuffix;
 			set
 			{
-				if (_appendAsSuffix == value) return;
-				_appendAsSuffix = value;
+				if (Settings.AppendAsSuffix == value) return;
+				Settings.AppendAsSuffix = value;
 				OnPropertyChanged(nameof(AppendAsSuffix));
 			}
 		}
 
 		public bool AppendCustomString
 		{
-			get => _appendCustomString;
+			get => Settings.AppendCustomString;
 			set
 			{
-				if (_appendCustomString == value) return;
-				_appendCustomString = value;
+				if (Settings.AppendCustomString == value) return;
+				Settings.AppendCustomString = value;
 				OnPropertyChanged(nameof(AppendCustomString));
 			}
 		}
 
 		public bool AppendTargetLanguage
 		{
-			get => _appendTargetLanguage;
+			get => Settings.AppendTargetLanguage;
 			set
 			{
-				if (_appendTargetLanguage == value) return;
-				_appendTargetLanguage = value;
+				if (Settings.AppendTargetLanguage == value) return;
+				Settings.AppendTargetLanguage = value;
 				OnPropertyChanged(nameof(AppendTargetLanguage));
 			}
 		}
@@ -88,34 +88,34 @@ namespace Trados.TargetRenamer.ViewModel
 
 		public string CustomLocation
 		{
-			get => _customLocation;
+			get => Settings.CustomLocation;
 			set
 			{
-				if (_customLocation == value) return;
-				_customLocation = value;
+				if (Settings.CustomLocation == value) return;
+				Settings.CustomLocation = value;
 				OnPropertyChanged(nameof(CustomLocation));
 			}
 		}
 
 		public string CustomString
 		{
-			get => _customString;
+			get => Settings.CustomString;
 			set
 			{
-				if (_customString == value) return;
-				_customString = value;
+				if (Settings.CustomString == value) return;
+				Settings.CustomString = value;
 				OnPropertyChanged(nameof(CustomString));
 			}
 		}
 
 		public string Delimiter
 		{
-			get => _delimiter;
+			get => Settings.Delimiter;
 			set
 			{
 				if (string.IsNullOrWhiteSpace(_delimiter)) _delimiter = "_";
-				if (_delimiter == value) return;
-				_delimiter = value;
+				if (Settings.Delimiter == value) return;
+				Settings.Delimiter = value;
 				OnPropertyChanged(nameof(Delimiter));
 			}
 		}
@@ -124,22 +124,22 @@ namespace Trados.TargetRenamer.ViewModel
 
 		public string RegularExpressionReplaceWith
 		{
-			get => _regularExpressionReplaceWith;
+			get => Settings.RegularExpressionReplaceWith;
 			set
 			{
-				if (_regularExpressionReplaceWith == value) return;
-				_regularExpressionReplaceWith = value;
+				if (Settings.RegularExpressionReplaceWith == value) return;
+				Settings.RegularExpressionReplaceWith = value;
 				OnPropertyChanged(nameof(RegularExpressionReplaceWith));
 			}
 		}
 
 		public string RegularExpressionSearchFor
 		{
-			get => _regularExpressionSearchFor;
+			get => Settings.RegularExpressionSearchFor;
 			set
 			{
-				if (_regularExpressionSearchFor == value) return;
-				_regularExpressionSearchFor = value;
+				if (Settings.RegularExpressionSearchFor == value) return;
+				Settings.RegularExpressionSearchFor = value;
 				OnPropertyChanged(nameof(RegularExpressionSearchFor));
 			}
 		}
@@ -166,33 +166,33 @@ namespace Trados.TargetRenamer.ViewModel
 
 		public bool UseCustomLocation
 		{
-			get => _useCustomLocation;
+			get => Settings.UseCustomLocation;
 			set
 			{
-				if (_useCustomLocation == value) return;
-				_useCustomLocation = value;
+				if (Settings.UseCustomLocation == value) return;
+				Settings.UseCustomLocation = value;
 				OnPropertyChanged(nameof(UseCustomLocation));
 			}
 		}
 
 		public bool UseRegularExpression
 		{
-			get => _useRegularExpression;
+			get => Settings.UseRegularExpression;
 			set
 			{
-				if (_useRegularExpression == value) return;
-				_useRegularExpression = value;
+				if (Settings.UseRegularExpression == value) return;
+				Settings.UseRegularExpression = value;
 				OnPropertyChanged(nameof(UseRegularExpression));
 			}
 		}
 
 		public bool UseShortLocales
 		{
-			get => _useShortLocales;
+			get => Settings.UseShortLocales;
 			set
 			{
-				if (_useShortLocales == value) return;
-				_useShortLocales = value;
+				if (Settings.UseShortLocales == value) return;
+				Settings.UseShortLocales = value;
 				OnPropertyChanged(nameof(UseShortLocales));
 			}
 		}

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
@@ -23,7 +23,6 @@ namespace Trados.TargetRenamer.ViewModel
 		private string _customLocation;
 		private string _customString;
 		private string _delimiter;
-		private bool _overwriteTargetFiles;
 		private string _regularExpressionReplaceWith;
 		private string _regularExpressionSearchFor;
 		private ICommand _resetToDefault;
@@ -122,17 +121,6 @@ namespace Trados.TargetRenamer.ViewModel
 		}
 
 		public bool HasErrors { get; internal set; } = false;
-
-		public bool OverwriteTargetFiles
-		{
-			get => _overwriteTargetFiles;
-			set
-			{
-				if (_overwriteTargetFiles == value) return;
-				_overwriteTargetFiles = value;
-				OnPropertyChanged(nameof(OverwriteTargetFiles));
-			}
-		}
 
 		public string RegularExpressionReplaceWith
 		{
@@ -242,7 +230,6 @@ namespace Trados.TargetRenamer.ViewModel
 
 		private void Reset(object obj)
 		{
-			OverwriteTargetFiles = true;
 			AppendAsPrefix = false;
 			AppendAsSuffix = true;
 			UseCustomLocation = false;

--- a/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
+++ b/TargetRenamer/Trados.TargetRenamer/Trados.TargetRenamer/ViewModel/TargetRenamerSettingsViewModel.cs
@@ -15,37 +15,25 @@ namespace Trados.TargetRenamer.ViewModel
 		private const string AppendSuffixText = "Append As Suffix";
 		private const string RegExprText = "Use Regular Expression";
 		private readonly IFolderDialogService _folderDialogService;
-		private bool _appendAsPrefix;
-		private bool _appendAsSuffix;
-		private bool _appendCustomString;
-		private bool _appendTargetLanguage;
 		private ICommand _clearCommand;
-		private string _customLocation;
-		private string _customString;
-		private string _delimiter;
-		private string _regularExpressionReplaceWith;
-		private string _regularExpressionSearchFor;
 		private ICommand _resetToDefault;
 		private string _selectedComboBoxItem;
 		private ICommand _selectTargetFolder;
-		private bool _useCustomLocation;
-		private bool _useRegularExpression;
-		private bool _useShortLocales;
+		private TargetRenamerSettings _settings;
 
 		public TargetRenamerSettingsViewModel(IFolderDialogService folderDialogService)
 		{
 			_folderDialogService = folderDialogService;
 			ComboBoxItems = new ObservableCollection<string> { AppendSuffixText, AppendPrefixText, RegExprText };
-			//Reset(null);
 		}
 
 		public bool AppendAsPrefix
 		{
-			get => _appendAsPrefix;
+			get => Settings.AppendAsPrefix;
 			set
 			{
-				if (_appendAsPrefix == value) return;
-				_appendAsPrefix = value;
+				if (Settings.AppendAsPrefix == value) return;
+				Settings.AppendAsPrefix = value;
 				OnPropertyChanged(nameof(AppendAsPrefix));
 			}
 		}
@@ -113,7 +101,7 @@ namespace Trados.TargetRenamer.ViewModel
 			get => Settings.Delimiter;
 			set
 			{
-				if (string.IsNullOrWhiteSpace(_delimiter)) _delimiter = "_";
+				if (string.IsNullOrWhiteSpace(Settings.Delimiter)) Settings.Delimiter = "_";
 				if (Settings.Delimiter == value) return;
 				Settings.Delimiter = value;
 				OnPropertyChanged(nameof(Delimiter));
@@ -162,7 +150,18 @@ namespace Trados.TargetRenamer.ViewModel
 		public ICommand SelectTargetFolder =>
 			_selectTargetFolder ?? (_selectTargetFolder = new CommandHandler(SelectFolder));
 
-		public TargetRenamerSettings Settings { get; set; }
+		public TargetRenamerSettings Settings
+		{
+			get => _settings; set
+			{
+				if (string.IsNullOrWhiteSpace(value.CustomLocation)) value.CustomLocation = Path.GetTempPath();
+				if (string.IsNullOrWhiteSpace(value.Delimiter)) value.Delimiter = "_";
+				if (!value.AppendTargetLanguage) value.AppendTargetLanguage = true;
+				_settings = value;
+
+				SelectedComboBoxItem = AppendSuffixText;
+			}
+		}
 
 		public bool UseCustomLocation
 		{


### PR DESCRIPTION
Add more input validation
Delete artifact file without extension, created when reverting to SDLXLIFF
Remember settings and set some defaults
Make UI responsive (different from 2021)
Remove "Overwrite target files" option as the app should do that every time