### PR TITLE
Added null validation when the provider is added from Translate singl…

### DIFF
--- a/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/TranslationOptions.cs
+++ b/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/TranslationOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using Newtonsoft.Json;
 using Sdl.Community.MTEdge.LPConverter;
 using Sdl.Community.MTEdge.Provider.Model;
@@ -16,12 +15,13 @@ namespace Sdl.Community.MTEdge.Provider
 	{
 		private string ResolvedHost { get; set; }
 		
-		readonly TranslationProviderUriBuilder _uriBuilder;
+		private readonly TranslationProviderUriBuilder _uriBuilder;
 
 		public TranslationOptions()
 		{
 			_uriBuilder = new TranslationProviderUriBuilder(TranslationProvider.TranslationProviderScheme);
 			UseBasicAuthentication = true;
+			RequiresSecureProtocol = false;
 			Port = 8001;
 			LPPreferences = new Dictionary<CultureInfo, SDLMTEdgeLanguagePair>();
 		}
@@ -43,7 +43,6 @@ namespace Sdl.Community.MTEdge.Provider
 		public bool UseBasicAuthentication { get; set; }
 		public bool RequiresSecureProtocol { get; set; }	
 
-		#region URI Properties
 		public string Host
 		{
 			get => _uriBuilder.HostName;
@@ -93,8 +92,6 @@ namespace Sdl.Community.MTEdge.Provider
 						mtEdgeLPs: installedLP.OrderBy(lp => lp.LanguagePairId).ToList())
 			).ToList();
 
-			var customEnginesMapping = new CustomEngines();
-
 			//Fix for Spanish latin amerincan flavours
 			CheckLatinSpanish(languagePairs, languagePairChoices, mtEdgeLanguagePairs);
 
@@ -110,7 +107,6 @@ namespace Sdl.Community.MTEdge.Provider
 		/// <summary>
 		/// Set dictionaries for each languagePairChoices 
 		/// </summary>
-		/// <param name="languagePairChoices"></param>
 		public void SetDictionaries(TradosToMTEdgeLP[] languagePairChoices)
 		{
 			foreach (var languagePair in languagePairChoices)
@@ -118,7 +114,6 @@ namespace Sdl.Community.MTEdge.Provider
 				SDLMTEdgeTranslatorHelper.GetDictionaries(languagePair, this);
 			}
 		}
-
 
 		private void CheckForPtbSource(LanguagePair[] languagePairs, List<TradosToMTEdgeLP> languagePairChoices, SDLMTEdgeLanguagePair[] mtEdgeLanguagePairs)
 		{
@@ -180,7 +175,6 @@ namespace Sdl.Community.MTEdge.Provider
 			}
 		}
 
-
 		/// <summary>
 		/// Used for flavours of a language to map the flavour to parent language code
 		/// </summary>
@@ -199,7 +193,5 @@ namespace Sdl.Community.MTEdge.Provider
 				}
 			}
 		}
-		
-		#endregion
 	}
 }

--- a/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/TranslationProviderFactory.cs
+++ b/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/TranslationProviderFactory.cs
@@ -14,55 +14,53 @@ namespace Sdl.Community.MTEdge.Provider
     {
 	    public static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-		public ITranslationProvider CreateTranslationProvider(
-			Uri translationProviderUri,
-			string translationProviderState,
-			ITranslationProviderCredentialStore credentialStore)
+	    public ITranslationProvider CreateTranslationProvider(
+		    Uri translationProviderUri,
+		    string translationProviderState,
+		    ITranslationProviderCredentialStore credentialStore)
+	    {
+		    _logger.Info("Attempting to create a new translation provider with URI: {0}", translationProviderUri);
+
+		    if (!SupportsTranslationProviderUri(translationProviderUri))
+		    {
+			    _logger.Error("Cannot handle URI {0}.", translationProviderUri);
+			    throw new Exception("Cannot handle URI.");
+		    }
+
+		    var credentials = credentialStore.GetCredential(translationProviderUri);
+		    if (credentials == null)
+		    {
+			    throw new TranslationProviderAuthenticationException();
+		    }
+
+		    var options = JsonConvert.DeserializeObject<TranslationOptions>(translationProviderState);
+		    var genericCredentials = new GenericCredentials(credentials.Credential);
+
+			if (options.UseBasicAuthentication)
+		    {
+			    options.ApiToken = SDLMTEdgeTranslatorHelper.GetAuthToken(options, genericCredentials);
+		    }
+		    else
+		    {
+			    options.ApiToken = genericCredentials["API-Key"];
+			    SDLMTEdgeTranslatorHelper.VerifyBasicAPIToken(options, genericCredentials);
+		    }
+
+			return new TranslationProvider(options);
+	    }
+
+	    public bool SupportsTranslationProviderUri(Uri translationProviderUri)
         {
-            _logger.Info("Attempting to create a new translation provider with URI: {0}", translationProviderUri);
-
-            if (!SupportsTranslationProviderUri(translationProviderUri))
-            {
-                _logger.Error("Cannot handle URI {0}.", translationProviderUri);
-                throw new Exception("Cannot handle URI.");
-            }
-
-            var credentials = credentialStore.GetCredential(translationProviderUri);
-            if (credentials == null)
-            {
-				return new TranslationProvider(new TranslationOptions());
-			}
-
-			var options = JsonConvert.DeserializeObject<TranslationOptions>(translationProviderState);
-            var genericCredentials = new GenericCredentials(credentials.Credential);
-
-            if (options.UseBasicAuthentication)
-            {
-                options.ApiToken = SDLMTEdgeTranslatorHelper.GetAuthToken(options, genericCredentials);
-            }
-            else
-            {
-                options.ApiToken = genericCredentials["API-Key"];
-                SDLMTEdgeTranslatorHelper.VerifyBasicAPIToken(options, genericCredentials);
-            }
-            return new TranslationProvider(options);
-        }
-
-        public bool SupportsTranslationProviderUri(Uri translationProviderUri)
-        {
-            _logger.Trace("");
-            if (translationProviderUri == null)
-            {
-                _logger.Error("Attempted to use null translation provider URI.");
-                throw new ArgumentNullException("translationProviderUri", "Translation provider URI not supported.");
-            }
-            return string.Equals(translationProviderUri.Scheme, TranslationProvider.TranslationProviderScheme, StringComparison.OrdinalIgnoreCase);
+	        if (translationProviderUri != null)
+		        return string.Equals(translationProviderUri.Scheme, TranslationProvider.TranslationProviderScheme,
+			        StringComparison.OrdinalIgnoreCase);
+	        _logger.Error("Attempted to use null translation provider URI.");
+            throw new ArgumentNullException("translationProviderUri", @"Translation provider URI not supported.");
         }
 
         public TranslationProviderInfo GetTranslationProviderInfo(Uri translationProviderUri, string translationProviderState)
         {
-            _logger.Trace("");
-            return new TranslationProviderInfo()
+            return new TranslationProviderInfo
             {
                 TranslationMethod = TranslationOptions.ProviderTranslationMethod,
                 Name = PluginResources.Plugin_NiceName

--- a/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/pluginpackage.manifest.xml
+++ b/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>SDL Machine Translation Edge</PlugInName>
-  <Version>3.0.5.1</Version>
+  <Version>3.0.5.2</Version>
   <Description>SDL Machine Translation Edge Provider</Description>
   <Author>SDL Community Developers</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0"/>


### PR DESCRIPTION
…e document.

Save Requires secure connection option and populate the ui when the plugin is added to another project.
Removed the validation when not all language pairs receives dictionary from Edge (in case we add the provider form Translate single document and we receive more language pairs). Put back tne Throw exception in Factory if the credentials were not found in Credential Store.