### PR TITLE
Updated so Google Translate V2 and V3 support plain text

### DIFF
--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/GoogleApi/GoogleV3Connecter.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/GoogleApi/GoogleV3Connecter.cs
@@ -55,10 +55,12 @@ namespace Sdl.Community.MtEnhancedProvider.GoogleApi
 			}
 		}
 
-		public string TranslateText(CultureInfo sourceLanguage, CultureInfo targetLanguage, string sorceText)
+		public string TranslateText(CultureInfo sourceLanguage, CultureInfo targetLanguage, string sorceText, string format)
 		{
 			try
 			{
+				// V2 uses "html" and "text" but for V3 its "text/html" and "text/plain"
+				var mimeType = format == "text" ? "text/plain" : "text/html";
 				var request = new TranslateTextRequest
 				{
 					Contents =
@@ -68,7 +70,8 @@ namespace Sdl.Community.MtEnhancedProvider.GoogleApi
 					Model = _modelPath,
 					TargetLanguageCode = targetLanguage.Name,
 					SourceLanguageCode = sourceLanguage.Name,
-					Parent = new ProjectName(_options.ProjectName).ToString()
+					Parent = new ProjectName(_options.ProjectName).ToString(),
+					MimeType = mimeType
 				};
 				if (!string.IsNullOrEmpty(_glossaryResourceLocation))
 				{

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderLanguageDirection.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/MtTranslationProviderLanguageDirection.cs
@@ -206,7 +206,7 @@ namespace Sdl.Community.MtEnhancedProvider
 			_googleV3Connecter = new GoogleV3Connecter(options);
 
 			var v3TranslatedText =
-				_googleV3Connecter.TranslateText(_languageDirection.SourceCulture, _languageDirection.TargetCulture, sourcetext);
+				_googleV3Connecter.TranslateText(_languageDirection.SourceCulture, _languageDirection.TargetCulture, sourcetext, format);
 
 			return v3TranslatedText;
 		}
@@ -309,7 +309,7 @@ namespace Sdl.Community.MtEnhancedProvider
 				{
 					//now do lookup
 					case MtTranslationOptions.ProviderType.GoogleTranslate:
-						translatedText = LookupGt(sourcetext, _options, "html"); //plain??
+						translatedText = LookupGt(sourcetext, _options, "text");
 						break;
 					case MtTranslationOptions.ProviderType.MicrosoftTranslator:
 						translatedText = LookupMst(sourcetext, _options, "text/plain");

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/Interface/IGoogleV3Connecter.cs
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/ViewModel/Interface/IGoogleV3Connecter.cs
@@ -6,7 +6,7 @@ namespace Sdl.Community.MtEnhancedProvider.ViewModel.Interface
 	public interface IGoogleV3Connecter
 	{
 		string GlossaryId { get; set; }
-		string TranslateText(CultureInfo sourceLanguage, CultureInfo targetLanguage, string sorceText);
+		string TranslateText(CultureInfo sourceLanguage, CultureInfo targetLanguage, string sorceText, string format);
 		void CreateGoogleGlossary(LanguagePair[] languagePairs);
 		void SetGoogleAvailableLanguages();
 		void TryToAuthenticateUser();

--- a/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/pluginpackage.manifest.xml
+++ b/MT Enhanced Provider/Sdl.Community.MtEnhancedProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 		<PlugInName>MT Enhanced Plugin for Trados Studio</PlugInName>
-		<Version>5.3.14.3</Version>
+		<Version>5.3.14.4</Version>
 		<Description>This plugin provides machine translation results from Microsoft Translator or Google Translate.</Description>
 		<Author>RWS AppStore Team</Author>
 		<Include>


### PR DESCRIPTION
Right now the Google Connector uses the html mimetype even for plain text causing issues with translations.
For example quotes becomes `&quot;` and left-angle brackets are recognized as tags.
Let me know if anything else needs to be changed/updated. Thanks.
