### PR TITLE
SDLCOM-3065: MT QE not retrieved in Studio file

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/RateIt/SegmentMetadataCreator.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/RateIt/SegmentMetadataCreator.cs
@@ -78,7 +78,7 @@ namespace Sdl.Community.MTCloud.Provider.Service.RateIt
 			if (string.IsNullOrWhiteSpace(projectPath)) return null;
 
 			string[] targetLanguageFiles;
-			if (Directory.GetDirectories(projectPath).Any(d => d == targetLanguage))
+			if (Directory.GetDirectories(projectPath).Any(d => d.Contains(targetLanguage)))
 			{
 				targetLanguageFiles = Directory.GetFiles($@"{projectPath}\{targetLanguage}");
 				filepath =

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/RateIt/SegmentMetadataCreator.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/RateIt/SegmentMetadataCreator.cs
@@ -72,13 +72,14 @@ namespace Sdl.Community.MTCloud.Provider.Service.RateIt
 			var projectPath = Path.GetDirectoryName(MtCloudApplicationInitializer.ProjectInCreationFilePath) ??
 			                  Path.GetDirectoryName(MtCloudApplicationInitializer.GetProjectInProcessing().FilePath);
 
-			var filepath = $@"{projectPath}\{targetLanguage}\{filename}.sdlxliff";
+			filename = filename.Contains(".sdlxliff") ? filename : $"{filename}.sdlxliff";
+			var filepath = $@"{projectPath}\{targetLanguage}\{filename}";
 
 			if (File.Exists(filepath)) return filepath;
 			if (string.IsNullOrWhiteSpace(projectPath)) return null;
 
 			string[] targetLanguageFiles;
-			if (Directory.GetDirectories(projectPath).Any(d => d.Contains(targetLanguage)))
+			if (Directory.GetDirectories(projectPath).Select(d => d.ToUpper()).Any(d => d.Contains(targetLanguage.ToUpper())))
 			{
 				targetLanguageFiles = Directory.GetFiles($@"{projectPath}\{targetLanguage}");
 				filepath =

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/TranslationProvider/SdlMTCloudLanguageDirection.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Studio/TranslationProvider/SdlMTCloudLanguageDirection.cs
@@ -249,7 +249,7 @@ namespace Sdl.Community.MTCloud.Provider.Studio.TranslationProvider
 		{
 			var sdlMtFileAndSegmentIds = new FileAndSegmentIds
 			{
-				FilePath = Path.GetFileName(translationUnits[0]?.FileProperties.FileConversionProperties.OriginalFilePath),
+				FilePath = Path.GetFileName(translationUnits[0]?.DocumentProperties.LastOpenedAsPath),
 				Segments = translationUnits.ToDictionary(tu => tu.DocumentSegmentPair.Properties.Id, tu => tu.SourceSegment.ToString())
 			};
 

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>Language Weaver Cloud</PlugInName>
-	<Version>4.2.15.6</Version>
+	<Version>4.2.15.7</Version>
 	<Description>Language Weaver Cloud</Description>
 	<Author>RWS AppStore Team</Author>
 	<Include>


### PR DESCRIPTION
LW Cloud 4.2.15.7
 - take file name from the document properties and then infer the rest of the file path from the project folder