### PR TITLE
Rebranding of MTEdge plugin

### DIFF
--- a/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/pluginpackage.manifest.xml
+++ b/SDLMTEdge.Provider/SDLMTEdgeTranslationProvider/pluginpackage.manifest.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
-  <PlugInName>SDL Machine Translation Edge</PlugInName>
+  <PlugInName>Language Weaver Edge</PlugInName>
   <Version>3.0.6.0</Version>
-  <Description>SDL Machine Translation Edge Provider</Description>
+  <Description>Language Weaver Edge Provider</Description>
   <Author>RWS AppStore Team</Author>
   <RequiredProduct name="SDLTradosStudio" minversion="16.0" maxversion="16.9"/>
   <Include>


### PR DESCRIPTION
Changed the plugin name  to Language Weaver Edge and description to Language Weaver Edge Provider