### PR TITLE
MTCloudProvider-Language Weaver Cloud Provider

### DIFF
--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Constants.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Constants.cs
@@ -2,7 +2,12 @@
 {
 	public class Constants
 	{
-		public static string MTCloudTranslateAPIUri = "https://api.languageweaver.com";
+		public static string MTCloudTranslateAPIUriEU = "https://api.languageweaver.com";
+		public static string MTCloudTranslateAPIUriUS = "https://us.api.languageweaver.com";
+
+		public static string MTCloudTranslateAPIUrlEULogin = "https://portal.languageweaver.com/login";
+		public static string MTCloudTranslateAPIUrlUSLogin = "https://us.portal.languageweaver.com/login";
+
 		public static string MTCloudTranslateUri = "https://translate.sdlbeglobal.com";
 		public static string MTCloudUriScheme = "sdlmtcloud";		
 		public static string MTCloudUriResourceUserToken = "/token/user";

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/EnumBooleanConverter.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/EnumBooleanConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Sdl.Community.MTCloud.Provider.Converters
+{
+
+	public class EnumBooleanConverter : IValueConverter
+	{
+
+		//public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		//{
+		//	return value != null && value.Equals(parameter);
+		//}
+
+		//public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		//{
+		//	return value != null && (bool)value ? parameter : Binding.DoNothing;
+		//}
+
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value == null || parameter == null) return false;
+			string enumValue = value.ToString();
+			string targetValue = parameter.ToString();
+			bool outputValue = enumValue.Equals(targetValue, StringComparison.InvariantCultureIgnoreCase);
+			return outputValue;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value == null || parameter == null) return null;
+			bool useValue = (bool)value;
+			string targetValue = parameter.ToString();
+			if (useValue) return Enum.Parse(targetType, targetValue);
+			return null;
+		}
+
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/VisibilityConverter.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Converters/VisibilityConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Data;
 
@@ -14,7 +15,12 @@ namespace Sdl.Community.MTCloud.Provider.Converters
 			{
 				var valueString = value?.ToString();
 				var parameterString = parameter?.ToString() ?? string.Empty;
-
+				if (parameterString.Contains("#"))
+				{
+					var parameters = parameterString.Split('#');
+					return parameters.Any(param => param.Equals(valueString, StringComparison.InvariantCultureIgnoreCase)) ? Visibility.Visible
+						: Visibility.Collapsed;
+				}
 				return string.Compare(parameterString, valueString, StringComparison.InvariantCultureIgnoreCase) == 0 
 					? Visibility.Visible 
 					: Visibility.Collapsed;

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Interfaces/IConnectionService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Interfaces/IConnectionService.cs
@@ -45,5 +45,6 @@ namespace Sdl.Community.MTCloud.Provider.Interfaces
 		void SaveCredential(ITranslationProviderCredentialStore credentialStore, bool persist = true);
 
 		ICredential GetCredential(ITranslationProviderCredentialStore credentialStore);
+		string CurrentWorkingPortalAddress { get; set; }
 	}
 }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/WorkingPortalsAddress.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Model/WorkingPortalsAddress.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sdl.Community.MTCloud.Provider.Model
+{
+	public enum WorkingPortal
+	{
+		UEPortal, 
+		USPortal
+	}
+
+	internal class WorkingPortalsAddress
+	{
+		internal static string GetWorkingPortalAddress(WorkingPortal viewModelSelectedWorkingPortal)
+		{
+			switch (viewModelSelectedWorkingPortal)
+			{
+				case WorkingPortal.UEPortal:
+					return Constants.MTCloudTranslateAPIUriEU;
+				case WorkingPortal.USPortal:
+					return Constants.MTCloudTranslateAPIUriUS;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(viewModelSelectedWorkingPortal), viewModelSelectedWorkingPortal, null);
+			}
+		}
+	}
+}

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.Designer.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.Designer.cs
@@ -213,6 +213,15 @@ namespace Sdl.Community.MTCloud.Provider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Account region:.
+        /// </summary>
+        public static string Label_AccountRegion {
+            get {
+                return ResourceManager.GetString("Label_AccountRegion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to OK.
         /// </summary>
         public static string Label_OK {
@@ -351,7 +360,7 @@ namespace Sdl.Community.MTCloud.Provider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please verify your credentials!.
+        ///   Looks up a localized string similar to Verify your credentials and try again..
         /// </summary>
         public static string Message_Please_verify_your_credentials {
             get {
@@ -942,6 +951,24 @@ namespace Sdl.Community.MTCloud.Provider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to login to the Language Weaver EU instance. Verify your credentials and try again..
+        /// </summary>
+        public static string UnableToConnectToWorkingEUPortal {
+            get {
+                return ResourceManager.GetString("UnableToConnectToWorkingEUPortal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to login to the Language Weaver US instance. Verify your credentials and try again..
+        /// </summary>
+        public static string UnableToConnectToWorkingUSPortal {
+            get {
+                return ResourceManager.GetString("UnableToConnectToWorkingUSPortal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
         public static string UnknownQuality {
@@ -992,6 +1019,24 @@ namespace Sdl.Community.MTCloud.Provider {
         public static string WindowsControl_Restore {
             get {
                 return ResourceManager.GetString("WindowsControl_Restore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Europe.
+        /// </summary>
+        public static string WorkingEUPortal {
+            get {
+                return ResourceManager.GetString("WorkingEUPortal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to US.
+        /// </summary>
+        public static string WorkingUSPortal {
+            get {
+                return ResourceManager.GetString("WorkingUSPortal", resourceCulture);
             }
         }
     }

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.resx
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/PluginResources.resx
@@ -212,7 +212,7 @@
     <value>User is signed out!</value>
   </data>
   <data name="Message_Please_verify_your_credentials" xml:space="preserve">
-    <value>Please verify your credentials!</value>
+    <value>Verify your credentials and try again.</value>
   </data>
   <data name="Message_Successfully_reset_language_mappings" xml:space="preserve">
     <value>Successfully reset language mappings</value>
@@ -419,9 +419,24 @@ Response from Language Weaver:
     <value>Language Weaver Cloud Rate Translations</value>
   </data>
   <data name="SDLMTCloud_Provider_OldName" xml:space="preserve">
-	  <value>SDL Machine Translation Cloud</value>
+    <value>SDL Machine Translation Cloud</value>
   </data>
   <data name="UnknownQuality" xml:space="preserve">
-	  <value>Unknown</value>
+    <value>Unknown</value>
+  </data>
+  <data name="UnableToConnectToWorkingEUPortal" xml:space="preserve">
+    <value>Unable to login to the Language Weaver EU instance. Verify your credentials and try again.</value>
+  </data>
+  <data name="UnableToConnectToWorkingUSPortal" xml:space="preserve">
+    <value>Unable to login to the Language Weaver US instance. Verify your credentials and try again.</value>
+  </data>
+  <data name="WorkingEUPortal" xml:space="preserve">
+    <value>Europe</value>
+  </data>
+  <data name="WorkingUSPortal" xml:space="preserve">
+    <value>US</value>
+  </data>
+  <data name="Label_AccountRegion" xml:space="preserve">
+    <value>Account region:</value>
   </data>
 </root>

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Properties/AssemblyInfo.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.4.0")]
-[assembly: AssemblyFileVersion("3.1.4.0")]
+[assembly: AssemblyVersion("4.2.18.0")]
+[assembly: AssemblyFileVersion("4.2.18.0")]

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Sdl.Community.MTCloud.Provider.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Controls\ToolWindowsControl.xaml.cs">
       <DependentUpon>ToolWindowsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converters\EnumBooleanConverter.cs" />
     <Compile Include="Converters\InvertableBoolEnabledConverter.cs" />
     <Compile Include="Events\ActiveSegmentQeChanged.cs" />
     <Compile Include="Events\RefreshQeStatus.cs" />
@@ -223,6 +224,7 @@
     <Compile Include="Model\TranslationResponseStats.cs" />
     <Compile Include="Model\TranslationResponseStatus.cs" />
     <Compile Include="Model\UserCredential.cs" />
+    <Compile Include="Model\WorkingPortalsAddress.cs" />
     <Compile Include="MTCloudApplicationInitializer.cs" />
     <Compile Include="PluginResources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/Service/TranslationService.cs
@@ -64,7 +64,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 				return;
 			}
 
-			var uri = new Uri($@"{Constants.MTCloudTranslateAPIUri}/v4/accounts/{ConnectionService.Credential.AccountId}/dictionaries/{dictionaryId}/terms");
+			var uri = new Uri($@"{ConnectionService.CurrentWorkingPortalAddress}/v4/accounts/{ConnectionService.Credential.AccountId}/dictionaries/{dictionaryId}/terms");
 			var request = GetRequestMessage(HttpMethod.Post, uri);
 
 			var content = JsonConvert.SerializeObject(term);
@@ -91,7 +91,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		{
 			CheckConnection();
 
-			var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4/accounts/{ConnectionService.Credential.AccountId}/dictionaries");
+			var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4/accounts/{ConnectionService.Credential.AccountId}/dictionaries");
 			var request = GetRequestMessage(HttpMethod.Get, uri);
 
 			var response = await _httpClient.SendRequest(request);
@@ -102,7 +102,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		{
 			CheckConnection();
 
-			var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4/accounts/{ConnectionService.Credential.AccountId}/subscriptions/language-pairs");
+			var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4/accounts/{ConnectionService.Credential.AccountId}/subscriptions/language-pairs");
 			var request = GetRequestMessage(HttpMethod.Get, uri);
 
 			var response = await _httpClient.SendRequest(request);
@@ -124,7 +124,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 			CheckConnection();
 
-			var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4/mt/translations/async");
+			var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4/mt/translations/async");
 			var request = GetRequestMessage(HttpMethod.Post, uri);
 
 			var engineModel = model.SelectedModel.Model;
@@ -188,7 +188,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private static void WaitForTranslation(TranslationResponseStatus responseStatus)
 		{
-			if (responseStatus.TranslationStatus.ToUpperInvariant() == Constants.DONE)
+			if (responseStatus.TranslationStatus.ToUpperInvariant() != Constants.DONE)
 			{
 				System.Threading.Thread.Sleep(300);
 			}
@@ -214,7 +214,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 			do
 			{
-				var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4/mt/translations/async/{id}");
+				var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4/mt/translations/async/{id}");
 				var request = GetRequestMessage(HttpMethod.Get, uri);
 
 				var responseMessage = await _httpClient.SendRequest(request);
@@ -306,7 +306,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 
 		private async Task<HttpResponseMessage> GetTranslationResult(string id)
 		{
-			var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4" + $"/mt/translations/async/{id}/content");
+			var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4" + $"/mt/translations/async/{id}/content");
 			var request = GetRequestMessage(HttpMethod.Get, uri);
 			var responseMessage = await _httpClient.SendRequest(request);
 			return responseMessage.IsSuccessStatusCode ? responseMessage : null;
@@ -321,7 +321,7 @@ namespace Sdl.Community.MTCloud.Provider.Service
 		{
 			CheckConnection();
 
-			var uri = new Uri($"{Constants.MTCloudTranslateAPIUri}/v4/accounts/{ConnectionService.Credential.AccountId}/feedback/translations");
+			var uri = new Uri($"{ConnectionService.CurrentWorkingPortalAddress}/v4/accounts/{ConnectionService.Credential.AccountId}/feedback/translations");
 
 			var request = GetRequestMessage(HttpMethod.Post, uri);
 			var serializerSettings =

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/View/CredentialsWindow.xaml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/View/CredentialsWindow.xaml
@@ -8,6 +8,7 @@
         xmlns:converters="clr-namespace:Sdl.Community.MTCloud.Provider.Converters"
         xmlns:watermark="clr-namespace:Sdl.Community.MTCloud.Provider.UiHelpers.Watermark"
         xmlns:controls="clr-namespace:Sdl.Community.MTCloud.Provider.Controls"
+        xmlns:provider="clr-namespace:Sdl.Community.MTCloud.Provider"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None" 
@@ -15,142 +16,156 @@
         ResizeMode="NoResize"
         d:DesignHeight="540" d:DesignWidth="630" Width="630" Height="540" 
         d:DataContext="{d:DesignInstance viewModel:CredentialsViewModel}">
-	<Window.Resources>
-		
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/Buttons.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/ComboBoxStyle.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/WindowsBorder.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/General.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/GroupBox.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/TextBoxStyle.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/RadioButton.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/TextBlockStyle.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/CustomProgressRing.xaml"/>
-				<ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/UiHelpers/Watermark/WatermarkTextBoxResources.xaml" />
-			</ResourceDictionary.MergedDictionaries>
+    <Window.Resources>
 
-			<converters:VisibilityConverter x:Key="VisibilityConverter"/>
-			<Style TargetType="Image">
-				<Setter Property="RenderOptions.BitmapScalingMode" Value="HighQuality" />
-			</Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/Buttons.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/ComboBoxStyle.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/WindowsBorder.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/General.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/GroupBox.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/TextBoxStyle.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/RadioButton.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/TextBlockStyle.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Styles/CustomProgressRing.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/UiHelpers/Watermark/WatermarkTextBoxResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-			<Style TargetType="{x:Type Window}">
-				<Setter Property="FontFamily" Value="Segoe UI" />
-				<Setter Property="FontSize" Value="11"/>
-				<Setter Property="Foreground" Value="{StaticResource WindowsControl.Control.Text}"/>
-			</Style>
-			<Style TargetType="{x:Type PasswordBox}">
-				<Setter Property="Height" Value="24"/>
-			</Style>
+            <converters:VisibilityConverter x:Key="VisibilityConverter"/>
+            <converters:EnumBooleanConverter x:Key="EnumBooleanConverter"/>
+            <Style TargetType="Image">
+                <Setter Property="RenderOptions.BitmapScalingMode" Value="HighQuality" />
+            </Style>
 
-		</ResourceDictionary>
-	</Window.Resources>
-	<Border Style="{StaticResource WindowControlBorderStyle}" >
-		<Grid Margin="1,0,0,0">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
-			</Grid.ColumnDefinitions>
-			<Grid.RowDefinitions>
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="20" />
-				<RowDefinition Height="*" />
-				<RowDefinition Height="Auto" />
-			</Grid.RowDefinitions>
+            <Style TargetType="{x:Type Window}">
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="Foreground" Value="{StaticResource WindowsControl.Control.Text}"/>
+            </Style>
+            <Style TargetType="{x:Type PasswordBox}">
+                <Setter Property="Height" Value="24"/>
+            </Style>
 
-			<!-- BORDER CONTROL -->
-			<controls:ToolWindowsControl  Grid.Column="0" Grid.Row="0" DockPanel.Dock="Top" />
-			<Image Grid.Row="0" Grid.Column="0" Height="40" Stretch="Uniform" HorizontalAlignment="Center" 
+        </ResourceDictionary>
+    </Window.Resources>
+    <Border Style="{StaticResource WindowControlBorderStyle}" >
+        <Grid Margin="1,0,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="20" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- BORDER CONTROL -->
+            <controls:ToolWindowsControl  Grid.Column="0" Grid.Row="0" DockPanel.Dock="Top" />
+            <Image Grid.Row="0" Grid.Column="0" Height="40" Stretch="Uniform" HorizontalAlignment="Center" 
 			       Margin="0 10 0 0" VerticalAlignment="Top"  IsHitTestVisible="False"
 			       Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Resources/LWLogo.png"/>
-			<!-- CONTENT AREA -->
+            <!-- CONTENT AREA -->
 
 
 
-			<Border Background="White" Grid.Column="0" Grid.Row="3">
-				<Grid>
-					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="*"/>
-					</Grid.ColumnDefinitions>
+            <Border Background="White" Grid.Column="0" Grid.Row="3">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-					<Grid.RowDefinitions>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="*"/>
-					</Grid.RowDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-					<Grid Grid.Column="0" Margin="30,10,20,0">
-						<TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="14">              
+                    <Grid Grid.Column="0" Margin="30,10,20,0">
+                        <TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="14">              
 							Select the authentication type and sign in with your credentials.
-						</TextBlock>
-					</Grid>
+                        </TextBlock>
+                    </Grid>
 
-					<Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="20">
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*"/>
-						</Grid.ColumnDefinitions>
+                    <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="20">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
 
-						<Grid.RowDefinitions>
-							<RowDefinition Height="*"/>
-						</Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                     
+                        <GroupBox Header="Authentication Type" Style="{StaticResource DefaultGroupBox}">
+                            <Grid Margin="3">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
 
-						<GroupBox Header="Authentication Type" Style="{StaticResource DefaultGroupBox}">
-							<Grid Margin="3">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*"/>
-								</Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="*"/>
-									<RowDefinition Height="Auto"/>
-								</Grid.RowDefinitions>
-
-								<ComboBox HorizontalAlignment="Left" Grid.Row="0"
+								<ComboBox  Grid.Row="0" HorizontalAlignment="Left"
 								           Width="400"
-										  Style="{StaticResource Sdl.ComboBox.Generic.Style}"
+								           Style="{StaticResource Sdl.ComboBox.Generic.Style}"
 								           ItemsSource="{Binding AuthenticationOptions}"
 								           SelectedItem="{Binding SelectedAuthentication, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
 								           DisplayMemberPath ="DisplayName" IsSynchronizedWithCurrentItem="True"
 								           Margin="0,5,0,10" 
 								           BorderThickness="1"
-										   BorderBrush="LightGray"/>
+								           BorderBrush="LightGray"/>
+								<!--<GroupBox Grid.Row="1" Width="400" HorizontalAlignment="Left">-->
 
-								<Grid Grid.Row="1"  >
-									<Grid.ColumnDefinitions>
+									<StackPanel Grid.Row="1"  Orientation="Horizontal" Visibility="{Binding SelectedAuthentication.Type, Converter={StaticResource VisibilityConverter}, ConverterParameter = 'User#Client'}">
+										<TextBlock Style="{StaticResource TextBlockColor}" 
+									           VerticalAlignment="Center" Margin="5,3,0,2" Text="{x:Static provider:PluginResources.Label_AccountRegion}"/> 
+									<RadioButton VerticalAlignment="Center" Name="btnUEPortal" Margin="50,3,0,2" GroupName="PortalsRadioGroup" 
+                                                 IsChecked="{Binding Path=SelectedWorkingPortal, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=UEPortal}" 
+                                                 Content="{x:Static provider:PluginResources.WorkingEUPortal}"/>
+                                    <RadioButton VerticalAlignment="Center" Name="btnUSPortal" Margin="50,3,0,2" GroupName="PortalsRadioGroup" 
+                                                 IsChecked="{Binding Path=SelectedWorkingPortal, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=USPortal}" 
+                                                 Content="{x:Static provider:PluginResources.WorkingUSPortal}"/>
+                                      </StackPanel>
+								<!--</GroupBox>-->
+                                <Grid Grid.Row="2">
+                                    <Grid.ColumnDefinitions>
 										<ColumnDefinition Width="*"/>
 									</Grid.ColumnDefinitions>
 
-									<Grid.RowDefinitions>
-										<RowDefinition Height="Auto"/>
-										<RowDefinition Height="Auto"/>
-										<RowDefinition Height="Auto"/>
-									</Grid.RowDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
 
-									<Grid Grid.Row="0"
+                                    <Grid Grid.Row="0"
 									      Visibility="{Binding SelectedAuthentication.Type, Converter={StaticResource VisibilityConverter}, ConverterParameter='Studio'}">
 
-										<StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Visibility="{Binding StudioIsSignedIn, Converter={StaticResource VisibilityConverter}, ConverterParameter='True'}">
-											<Image Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Resources/success.png" Margin="0,0,10,0"  Height="18" VerticalAlignment="Center"/>
-											<TextBlock Style="{StaticResource TextBlockColor}" Text="Signed in as: " VerticalAlignment="Center"/>
-											<TextBlock Style="{StaticResource TextBlockColor}" Text="{Binding StudioSignedInAs, FallbackValue='e-mail address'}"/>
-										</StackPanel>
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Visibility="{Binding StudioIsSignedIn, Converter={StaticResource VisibilityConverter}, ConverterParameter='True'}">
+                                            <Image Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Resources/success.png" Margin="0,0,10,0"  Height="18" VerticalAlignment="Center"/>
+                                            <TextBlock Style="{StaticResource TextBlockColor}" Text="Signed in as: " VerticalAlignment="Center"/>
+                                            <TextBlock Style="{StaticResource TextBlockColor}" Text="{Binding StudioSignedInAs, FallbackValue='e-mail address'}"/>
+                                        </StackPanel>
 
-										<StackPanel Orientation="Horizontal" Visibility="{Binding StudioIsSignedIn, Converter={StaticResource VisibilityConverter}, ConverterParameter='False'}">
-											<Image Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Resources/warning.png" Margin="0,0,10,0" Height="18" VerticalAlignment="Center"/>
-											<TextBlock Style="{StaticResource TextBlockColor}" Text="Signed out" VerticalAlignment="Center"/>
-										</StackPanel>
-									</Grid>
+                                        <StackPanel Orientation="Horizontal" Visibility="{Binding StudioIsSignedIn, Converter={StaticResource VisibilityConverter}, ConverterParameter='False'}">
+                                            <Image Source="pack://application:,,,/Sdl.Community.MTCloud.Provider;component/Resources/warning.png" Margin="0,0,10,0" Height="18" VerticalAlignment="Center"/>
+                                            <TextBlock Style="{StaticResource TextBlockColor}" Text="Signed out" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Grid>
 
-									<Grid Grid.Row="1" Margin="10"
+                                    <Grid Grid.Row="1" Margin="10"
 									      Visibility="{Binding SelectedAuthentication.Type, Converter={StaticResource VisibilityConverter}, ConverterParameter='User'}">
-										<StackPanel Orientation="Vertical" >
-											<TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,20">              
+                                        <StackPanel Orientation="Vertical" >
+                                            <TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,20">              
 												The Email and Password credentials used to sign in to the Language Weaver Cloud API.
-											</TextBlock>
+                                            </TextBlock>
 
-											<TextBox Name="UserNameBox"
+                                            <TextBox Name="UserNameBox"
 													 Style="{StaticResource WatermarkTextBox}"
 											         watermark:TextBoxWatermarkHelper.WatermarkText="Email"
 											         watermark:TextBoxWatermarkHelper.ButtonCommandParameter="UserName"
@@ -159,80 +174,91 @@
 											         Width="400" HorizontalAlignment="Left"
 											         Margin="0,0,0,10"
 											         IsEnabled="True">
-											</TextBox>
-											<PasswordBox Name="UserPasswordBox"
+                                            </TextBox>
+                                            <PasswordBox Name="UserPasswordBox"
 														 PasswordChanged="UserPasswordBox_PasswordChanged"
 							                             Width="400" HorizontalAlignment="Left"
 							                             Margin="0,0,0,10"
 							                             IsEnabled="True"/>
-										</StackPanel>
-									</Grid>
+                                        </StackPanel>
+                                    </Grid>
 
-									<Grid Grid.Row="2" Margin="10"
+                                    <Grid Grid.Row="2" Margin="10"
 									      Visibility="{Binding SelectedAuthentication.Type, Converter={StaticResource VisibilityConverter}, ConverterParameter='Client'}">
-										<StackPanel Orientation="Vertical" >
-											<TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,10">              
+                                        <StackPanel Orientation="Vertical" >
+                                            <TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,10">              
 										    The Client ID and Secret used to sign in to the Language Weaver Cloud API.
-											</TextBlock>
-											<TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,20">              
+                                            </TextBlock>
+                                            <TextBlock TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,20">              
 												Note: The Client ID and Secret can be retrieved by a Machine Translation Cloud administrator from the 
 												<Hyperlink NavigateUri="https://translate.sdlbeglobal.com/" Command="{Binding NavigateToCommand}" CommandParameter="{Binding NavigateUri, RelativeSource={RelativeSource Self}}">
 													Machine Translation Cloud user interface</Hyperlink>
-											</TextBlock>
+                                            </TextBlock>
 
-											<PasswordBox Name="ClientIdBox"
+                                            <PasswordBox Name="ClientIdBox"
 											             Width="400" HorizontalAlignment="Left"
 											             Margin="0,0,0,10"
 														 PasswordChanged="ClientIdBox_PasswordChanged"
 											             IsEnabled="True"/>
-											<PasswordBox Name="ClientSecretBox"
+                                            <PasswordBox Name="ClientSecretBox"
 														 PasswordChanged="ClientSecretBox_PasswordChanged"
 											             Width="400" HorizontalAlignment="Left"
 											             Margin="0,0,0,10"
 											             IsEnabled="True"/>
-										</StackPanel>
-									</Grid>
-								</Grid>
-							</Grid>
-						</GroupBox>
+                                        </StackPanel>
+                                    </Grid>
+                                </Grid>
+                            </Grid>
+                        </GroupBox>
 
-					</Grid>
-				</Grid>
+                    </Grid>
+                </Grid>
 
-			</Border>
+            </Border>
 
-			
 
-			<controls:CustomProgressRing Grid.Column="0" Grid.Row="3" x:Name="ProgressRing" Margin="0"
+
+            <controls:CustomProgressRing Grid.Column="0" Grid.Row="3" x:Name="ProgressRing" Margin="0"
 			                             Style="{StaticResource Sdl.CustomProgressRing.Normal}"
 			                             Visibility="{Binding IsInProgress, Converter= {StaticResource VisibilityConverter}, ConverterParameter='True', UpdateSourceTrigger=PropertyChanged}" />
 
 
-			<!-- BUTTONS -->
-			<Border Grid.Column="0" HorizontalAlignment="Center" Grid.Row="4" Margin="0,0,0,30">
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition/>
-						<RowDefinition/>
-					</Grid.RowDefinitions>
-					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="*" />
-						<ColumnDefinition Width="Auto" />
-						<ColumnDefinition Width="Auto" />
-					</Grid.ColumnDefinitions>
+            <!-- BUTTONS -->
+            <Border Grid.Column="0" HorizontalAlignment="Center" Grid.Row="4" Margin="0,0,0,20">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-					<TextBlock Grid.Row="0" Grid.Column="1" 
+                    <TextBlock Grid.Row="0" Grid.Column="1" 
 					           Text="{Binding ExceptionMessage, FallbackValue='Exception Message: This is an example message.'}" 
 					           TextWrapping="Wrap" Width="Auto" 
 					           Style="{StaticResource TextBlockColor}" 
 					           Foreground="DarkRed"/>
-					<Button Grid.Column="1" Grid.Row="1" 
+                    <TextBlock x:Name="LoginWeaverPortalLink"  Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+					           VerticalAlignment="Center" HorizontalAlignment="Center" 
+					           TextWrapping="Wrap" Width="Auto" Style="{StaticResource TextBlockColor}" FontSize="13" Margin="0,0,0,10">              
+						<Hyperlink NavigateUri="{Binding Path=CurrentWeaverWorkingPlatformsUriLogin}" x:Name="PortalUriLoginLink"
+						           
+						           Command="{Binding NavigateToCommand}" 
+						           CommandParameter="{Binding NavigateUri, RelativeSource={RelativeSource Self}}">
+							<TextBlock Text="{Binding Path=CurrentWeaverWorkingPlatformsUriLogin}"/>
+						</Hyperlink>
+					</TextBlock>
+                    <Button Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="2" 
 							Margin="0 10 0 0"
 					        Command="{Binding Path=SignInCommand}"
 							HorizontalAlignment="Center"
 					        Style="{StaticResource ButtonStyleGreenShadowless}" Content="{Binding SignInLabel}"/>
-				</Grid>
-			</Border>
-		</Grid>
-	</Border>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
 </Window>

--- a/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
+++ b/SDLMTCloud.Provider/Sdl.Community.MTCloud.Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>Language Weaver Cloud</PlugInName>
-	<Version>4.2.17.1</Version>
+	<Version>4.2.18.0</Version>
 	<Description>Language Weaver Cloud</Description>
 	<Author>RWS AppStore Team</Author>
 	<Include>
@@ -11,5 +11,5 @@
 		<File>Sdl.Community.MTCloud.Languages.Provider.dll</File>
 		<File>Sdl.Community.RateItControl.dll</File>
 	</Include>
-	<RequiredProduct name="SDLTradosStudio" minversion="16.2"/>
+	<RequiredProduct name="SDLTradosStudio" minversion="16.2" maxversion="16.9"/>
 </PluginPackage>


### PR DESCRIPTION
Changes for SDLCOM-3277 and its related CRQ-28443.
**NMT Service Region Governance**
Currently the fulfilment team for enterprise customers set the users up on a portal based on user location. Either being Europe or US. Portals are 
Based on portal location, it should determine which NMT platform they use. Either being:
- api.languageweaver.com for Europe
- us.api.languageweaver.com for US