### PR TITLE
Changes for Deploy Studio 2021 Plugins: TQA SDLCOM-3349

### DIFF
--- a/TQA/TQA/Properties/AssemblyInfo.cs
+++ b/TQA/TQA/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle( "TQA" )]
-[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyDescription("Translation Quality Assessment")]
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "" )]
 [assembly: AssemblyProduct( "TQA" )]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.0.0.0" )]
-[assembly: AssemblyFileVersion( "1.0.0.0" )]
+[assembly: AssemblyVersion( "3.0.0.0" )]
+[assembly: AssemblyFileVersion("3.0.8.0")]

--- a/TQA/TQA/Sdl.Community.TQA.csproj
+++ b/TQA/TQA/Sdl.Community.TQA.csproj
@@ -50,54 +50,34 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Sdl.Core.Globalization">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.Core.Globalization.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.Desktop.IntegrationApi">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.Desktop.IntegrationApi.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.Desktop.IntegrationApi.Extensions">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.Desktop.IntegrationApi.Extensions.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.TranslationStudioAutomation.IntegrationApi">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.TranslationStudioAutomation.IntegrationApi.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.TranslationStudioAutomation.IntegrationApi.Extensions">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.TranslationStudioAutomation.IntegrationApi.Extensions.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.FileTypeSupport.Framework.Core">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.FileTypeSupport.Framework.Core.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.FileTypeSupport.Framework.Implementation">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.FileTypeSupport.Framework.Implementation.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.ProjectAutomation.Core">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.ProjectAutomation.Core.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.ProjectAutomation.FileBased">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.ProjectAutomation.FileBased.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Sdl.ProjectAutomation.Settings">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramFiles)\SDL\SDL Trados Studio\Studio16\Sdl.ProjectAutomation.Settings.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -178,25 +158,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml">
-      <Version>2.7.2</Version>
+      <Version>2.16.0</Version>
     </PackageReference>
     <PackageReference Include="ExcelNumberFormat">
-      <Version>1.0.3</Version>
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="FastMember.Signed">
-      <Version>1.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6.1</Version>
+      <Version>1.5.0</Version>
     </PackageReference>
     <PackageReference Include="Sdl.Core.PluginFramework">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Sdl.Core.PluginFramework.Build">
-      <Version>16.0.1</Version>
+      <Version>16.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Packaging">
-      <Version>4.5.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/TQA/TQA/app.config
+++ b/TQA/TQA/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="DocumentFormat.OpenXml" publicKeyToken="8fb06cb64d019a17" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.9.1.0" newVersion="2.9.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.1.0" newVersion="2.16.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/TQA/TQA/pluginpackage.manifest.xml
+++ b/TQA/TQA/pluginpackage.manifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>TQA</PlugInName>
-  <Version>3.0.7.3</Version>
+  <Version>3.0.8.0</Version>
   <Description>TQA</Description>
-  <Author>RWS AppStore Team</Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="16.0" />
+  <Author>Trados AppStore Team</Author>
+  <RequiredProduct name="SDLTradosStudio" minversion="16.0" maxversion="16.9"/>
   <Include>
     <File>ClosedXML.dll</File>
     <File>DocumentFormat.OpenXml.dll</File>


### PR DESCRIPTION
Deploy Studio 2021 Plugins: TQA
Update maxversion property of the manifest to16.9. Plugin and assemblies version set to 3.0.8.0
Checked the projects references.
Updated Author to Trados AppStore Team
Checked and delete the private and specific version atribute of dll references.
Updated the NUget packages to last versions (removed NETStandard.Library package-not used)
Updated information into Plugin Releases document