### PR TITLE
Removed the / from plugin name. "SDLXLIFF Split/Merge" it is now "SDL…

### DIFF
--- a/SDLXLIFFSplitMerge/Sdl.Community.SDLXLIFFSplitMerge/pluginpackage.manifest.xml
+++ b/SDLXLIFFSplitMerge/Sdl.Community.SDLXLIFFSplitMerge/pluginpackage.manifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
-  <PlugInName>SDLXLIFF Split/Merge</PlugInName>
+  <PlugInName>SDLXLIFF Split and Merge</PlugInName>
   <Version>3.0.1.0</Version>
   <Description>Split and merge .sdlxliff files</Description>
   <Author>Trados AppStore Team</Author>


### PR DESCRIPTION
…XLIFF Split and Merge".