### PR TITLE
DeepL 7.0.4.3: SDLCOM-6163

### DIFF
--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/GlobalSettings.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/GlobalSettings.cs
@@ -4,6 +4,7 @@ using Sdl.Community.DeepLMTProvider.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows;
 
 namespace Sdl.Community.DeepLMTProvider
 {
@@ -31,8 +32,22 @@ namespace Sdl.Community.DeepLMTProvider
         private static Dictionary<(string, string), string> LoadGlossaryIds()
         {
             if (!File.Exists(FileName)) return new();
-            var globalSettingsSerialized = File.ReadAllLines(FileName);
-            return DeserializeGlossaryIds(globalSettingsSerialized);
+
+            try
+            {
+                var globalSettingsSerialized = File.ReadAllLines(FileName);
+                return DeserializeGlossaryIds(globalSettingsSerialized);
+            }
+            catch
+            {
+                File.Delete(FileName);
+                MessageBox.Show(
+                    PluginResources
+                        .GlobalSettings_LoadGlossaryIds_Global_settings_deserialization_failed__Settings_were_reset_to_default_,
+                    PluginResources.GlobalSettings_LoadGlossaryIds_Global_settings, MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return new Dictionary<(string, string), string>();
+            }
         }
 
         private static Dictionary<(string, string), string> DeserializeGlossaryIds(string[] globalSettingsSerialized)

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/PluginResources.Designer.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/PluginResources.Designer.cs
@@ -166,6 +166,25 @@ namespace Sdl.Community.DeepLMTProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Global settings.
+        /// </summary>
+        public static string GlobalSettings_LoadGlossaryIds_Global_settings {
+            get {
+                return ResourceManager.GetString("GlobalSettings_LoadGlossaryIds_Global_settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Global settings deserialization failed. Settings were reset to default..
+        /// </summary>
+        public static string GlobalSettings_LoadGlossaryIds_Global_settings_deserialization_failed__Settings_were_reset_to_default_ {
+            get {
+                return ResourceManager.GetString("GlobalSettings_LoadGlossaryIds_Global_settings_deserialization_failed__Settings_w" +
+                        "ere_reset_to_default_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap Information {

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/PluginResources.resx
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/PluginResources.resx
@@ -221,4 +221,10 @@ The formatting aspects affected by this setting include:
   <data name="ValidateButton.ToolTip" xml:space="preserve">
     <value>Highlight terms that are missing source or target text, or are duplicated.</value>
   </data>
+  <data name="GlobalSettings_LoadGlossaryIds_Global_settings_deserialization_failed__Settings_were_reset_to_default_" xml:space="preserve">
+    <value>Global settings deserialization failed. Settings were reset to default.</value>
+  </data>
+  <data name="GlobalSettings_LoadGlossaryIds_Global_settings" xml:space="preserve">
+    <value>Global settings</value>
+  </data>
 </root>

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.4.1")]
+[assembly: AssemblyFileVersion("7.0.4.2")]

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.4.2")]
+[assembly: AssemblyFileVersion("7.0.4.3")]

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/UI/DeepLWindow.xaml.cs
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/UI/DeepLWindow.xaml.cs
@@ -14,9 +14,14 @@ namespace Sdl.Community.DeepLMTProvider.UI
             Loaded += DeepLWindow_Loaded;
         }
 
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
         private void DeepLWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            ApiVersionCombobox.SelectedIndex = 0;
+            if (ApiVersionCombobox.SelectedIndex == -1) ApiVersionCombobox.SelectedIndex = 0;
         }
 
         private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
@@ -27,11 +32,6 @@ namespace Sdl.Community.DeepLMTProvider.UI
         private void Ok_Click(object sender, RoutedEventArgs e)
         {
             DialogResult = true;
-            Close();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
             Close();
         }
     }

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>DeepL Translation Provider</PlugInName>
-	<Version>7.0.4.1</Version>
+	<Version>7.0.4.2</Version>
 	<Description>This plugin provides machine translation results from the DeepL Translator.</Description>
 	<Author>Trados AppStore Team</Author>
 	<RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />

--- a/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepLMTProvider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>DeepL Translation Provider</PlugInName>
-	<Version>7.0.4.2</Version>
+	<Version>7.0.4.3</Version>
 	<Description>This plugin provides machine translation results from the DeepL Translator.</Description>
 	<Author>Trados AppStore Team</Author>
 	<RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />


### PR DESCRIPTION
- fix out of memory exception
- show correct API version choice in UI
