### PR TITLE
Fix #1651 StartTransit return package not including files when subfolders are not used

### DIFF
--- a/StarTransit/Sdl.Community.StarTransit.Shared/Services/ReturnPackageService.cs
+++ b/StarTransit/Sdl.Community.StarTransit.Shared/Services/ReturnPackageService.cs
@@ -124,7 +124,8 @@ namespace Sdl.Community.StarTransit.Shared.Services
 
         private static void AddFileToArchive(int encodingCode, ProjectFile targetFile, ZipArchive archive)
         {
-            archive.CreateEntry(targetFile.Folder);
+            if (!string.IsNullOrEmpty(targetFile.Folder))
+                archive.CreateEntry(targetFile.Folder);
 
             var pathToTargetFileFolder = Path.GetDirectoryName(targetFile.LocalFilePath);
             var fileName = Path.GetFileNameWithoutExtension(targetFile.LocalFilePath);


### PR DESCRIPTION
Fix #1651 StartTransit return package not including files when subfolders are not used.