### PR TITLE
ApplyTMTemplate 3.1.2.0 - SDLCOM-6420:

### DIFF
--- a/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Models/LanguageResourcesTemplate.cs
+++ b/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Models/LanguageResourcesTemplate.cs
@@ -7,7 +7,27 @@ namespace Sdl.Community.ApplyTMTemplate.Models
 {
 	public class LanguageResourcesTemplate : FileBasedLanguageResourcesTemplate, ILanguageResourcesContainer
 	{
-		public LanguageResourcesTemplate(string filePath) : base(filePath) {}
+		public LanguageResourcesTemplate(string filePath) : base(filePath)
+		{
+			var bundles = this.LanguageResourceBundles;
+
+			// Method used to make sure the bundle properties are populated
+			// Might remove it when initializing the TM works
+			foreach (var bundle in bundles)
+			{
+				_ = bundle.Abbreviations;
+				_ = bundle.CurrencyFormats;
+				_ = bundle.LongDateFormats;
+				_ = bundle.LongTimeFormats;
+				_ = bundle.MeasurementUnits;
+				_ = bundle.NumbersSeparators;
+				_ = bundle.OrdinalFollowers;
+				_ = bundle.SegmentationRules;
+				_ = bundle.ShortDateFormats;
+				_ = bundle.ShortTimeFormats;
+				_ = bundle.Variables;
+			}
+		}
 
 		public new BuiltinRecognizers Recognizers
 		{

--- a/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Models/TranslationMemory.cs
+++ b/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Models/TranslationMemory.cs
@@ -22,6 +22,25 @@ namespace Sdl.Community.ApplyTMTemplate.Models
 			_targetStatusToolTip = PluginResources.Nothing_processed_yet;
 			_isSelected = false;
 			LanguageResourceBundles.CollectionChanged += LanguageResourceBundles_CollectionChanged;
+
+			var bundles = this.LanguageResourceBundles;
+
+			// Method used to make sure the bundle properties are populated
+			// Might remove it when initializing the TM works
+			foreach (var bundle in bundles)
+			{
+				_ = bundle.Abbreviations;
+				_ = bundle.CurrencyFormats;
+				_ = bundle.LongDateFormats;
+				_ = bundle.LongTimeFormats;
+				_ = bundle.MeasurementUnits;
+				_ = bundle.NumbersSeparators;
+				_ = bundle.OrdinalFollowers;
+				_ = bundle.SegmentationRules;
+				_ = bundle.ShortDateFormats;
+				_ = bundle.ShortTimeFormats;
+				_ = bundle.Variables;
+			}
 		}
 
 		public event PropertyChangedEventHandler PropertyChanged;

--- a/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Properties/AssemblyInfo.cs
+++ b/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.1.1.3")]
+[assembly: AssemblyFileVersion("3.1.2.0")]

--- a/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/ViewModels/MainWindowViewModel.cs
+++ b/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/ViewModels/MainWindowViewModel.cs
@@ -192,7 +192,7 @@ namespace Sdl.Community.ApplyTMTemplate.ViewModels
 				_filePathDialogService.GetFilesFromFolderInputByUser(
 					PluginResources.Please_select_the_folder_containing_the_TMs, _tmPath);
 
-			if (filesPaths == null) return;
+			if (filesPaths is null || !filesPaths.Any()) return;
 
 			_tmPath = filesPaths[0];
 			AddRangeOfTms(_tmLoader.GetTms(filesPaths, TmCollection));
@@ -210,7 +210,7 @@ namespace Sdl.Community.ApplyTMTemplate.ViewModels
 		private void AddTms()
 		{
 			var filePaths = _filePathDialogService.GetFilePathInputFromUser(filter: "Translation Memories|*.sdltm", initialDirectory: _tmPath, multiselect: true);
-			if (filePaths == null) return;
+			if (filePaths is null || !filePaths.Any()) return;
 			_tmPath = filePaths[0];
 			AddRangeOfTms(_tmLoader.GetTms(filePaths, TmCollection));
 		}

--- a/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/pluginpackage.manifest.xml
+++ b/ApplyTMTemplate/Sdl.Community.ApplyTMTemplate/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>applyTM Template</PlugInName>
-  <Version>3.1.1.3</Version>
+  <Version>3.1.2.0</Version>
   <Description>This plugin adds support for managing and applying the settings in a Language Resource Template to multiple translation memories in one go.</Description>
   <Author>Trados AppStore Team</Author>
   <Include>


### PR DESCRIPTION
Refactor ResourceManagers and Fix MainWindowViewModel Error

- Modified ResourceManagers to allow applying a second template on an existing Translation Memory.
- Updated Excel and SDLTMS imports to use language resources, preventing modification of bundles with non-targeted languages.
- Fixed IndexOutOfRangeException in MainWindowViewModel when adding files.