### PR TITLE
Amazon Translate MT provider 5.0.1.0 - SDLCOM-6469:

### DIFF
--- a/Amazon Translate MT provider/Properties/AssemblyInfo.cs
+++ b/Amazon Translate MT provider/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.3")]
+[assembly: AssemblyFileVersion("5.0.1.0")]
 

--- a/Amazon Translate MT provider/Sdl.Community.AmazonTranslateTradosPlugin.csproj
+++ b/Amazon Translate MT provider/Sdl.Community.AmazonTranslateTradosPlugin.csproj
@@ -73,7 +73,7 @@
 	
 	<ItemGroup>
 		<Content Include="Resources\%24this.Icon.ico" />
-		<EntityDeploy Include="Resources\AmazonTranslate.ico" />
+		<None Include="Resources\AmazonTranslate.ico" />
 		<None Include="Resources\Question.ico" />
 		<None Include="Resources\ForumIcon.ico" />
 		<None Include="Resources\Download.ico" />

--- a/Amazon Translate MT provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
+++ b/Amazon Translate MT provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
@@ -97,14 +97,6 @@ namespace Sdl.Community.AmazonTranslateTradosPlugin.Studio.TranslationProvider
                 SourceSegment = segment.Duplicate()
             };
 
-            if (!_options.ResendDrafts && _inputTu.ConfirmationLevel != ConfirmationLevel.Unspecified) //i.e. if it's status is other than untranslated
-            { //don't do the lookup, b/c we don't need to pay google to translate text already translated if we edit a segment
-                translation.Add(PluginResources.TranslationLookupDraftNotResentMessage);
-                //later get these strings from resource file
-                results.Add(CreateSearchResult(segment, translation, segment.ToString()));
-                return results;
-            }
-
             // Look up the currently selected segment in the collection (normal segment lookup).
 
             string translatedText;
@@ -228,9 +220,12 @@ namespace Sdl.Community.AmazonTranslateTradosPlugin.Studio.TranslationProvider
             tu.ResourceId = new PersistentObjectToken(tu.GetHashCode(), Guid.Empty);
 
             var score = 0; //score to 0...change if needed to support scoring
-            tu.Origin = TranslationUnitOrigin.MachineTranslation;
-            var searchResult = new SearchResult(tu);
-            searchResult.ScoringResult = new ScoringResult();
+            tu.Origin = TranslationUnitOrigin.Nmt;
+            var searchResult = new SearchResult(tu)
+            {
+                TranslationProposal = new TranslationUnit(tu),
+                ScoringResult = new ScoringResult(),
+            };
             searchResult.ScoringResult.BaseScore = score;
             tu.ConfirmationLevel = ConfirmationLevel.Draft;
 

--- a/Amazon Translate MT provider/pluginpackage.manifest.xml
+++ b/Amazon Translate MT provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Amazon Translate MT provider</PlugInName>
-  <Version>5.0.0.3</Version>
+  <Version>5.0.1.0</Version>
   <Description>This plugin provides machine translation from the Amazon Translate Service AWS.</Description>
   <Author>Trados AppStore Team</Author>
 	<Include>


### PR DESCRIPTION
- Modified the Translation Unit to NMT
- Enhanced the Search Segment to prevent returning a hardcoded translation for already translated segments
- Updated the CreateSearchResult method to include a Translation Proposal