### PR TITLE
Amazon Translate MT Provider 5.0.1.1 - SDLCOM-6469

### DIFF
--- a/Amazon Translate MT provider/Properties/AssemblyInfo.cs
+++ b/Amazon Translate MT provider/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.1.0")]
+[assembly: AssemblyFileVersion("5.0.1.1")]
 

--- a/Amazon Translate MT provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
+++ b/Amazon Translate MT provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
@@ -97,6 +97,12 @@ namespace Sdl.Community.AmazonTranslateTradosPlugin.Studio.TranslationProvider
                 SourceSegment = segment.Duplicate()
             };
 
+            if (!_options.ResendDrafts && _inputTu.ConfirmationLevel != ConfirmationLevel.Unspecified) //i.e. if it's status is other than untranslated
+            { 
+                //don't do the lookup, b/c we don't need to pay google to translate text already translated if we edit a segment
+                return results;
+            }
+
             // Look up the currently selected segment in the collection (normal segment lookup).
 
             string translatedText;

--- a/Amazon Translate MT provider/pluginpackage.manifest.xml
+++ b/Amazon Translate MT provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Amazon Translate MT provider</PlugInName>
-  <Version>5.0.1.0</Version>
+  <Version>5.0.1.1</Version>
   <Description>This plugin provides machine translation from the Amazon Translate Service AWS.</Description>
   <Author>Trados AppStore Team</Author>
 	<Include>


### PR DESCRIPTION
- Updated SearchSegment to return an empty SearchResult list when the ResendDraft option is disabled, and the segment status is not Unspecified.