### PR TITLE
DeepL Translation Provider - 7.0.8.1 - SDLCOM-6492:

### DIFF
--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Interface/ITranslationProviderExtension.cs
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Interface/ITranslationProviderExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sdl.Community.DeepLMTProvider.Interface
+{
+    public interface ITranslationProviderExtension
+    {
+        public Dictionary<string, string> LanguagesSupported { get; set; }
+    }
+}

--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Model/DeepLCachedResult.cs
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Model/DeepLCachedResult.cs
@@ -1,0 +1,21 @@
+﻿using Sdl.Core.Globalization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.PeerResolvers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sdl.Community.DeepLMTProvider.Model
+{
+    public class DeepLCachedResult
+    {
+        public string SourceText { get; set; }
+
+        public string TargetText { get; set; }
+
+        public CultureCode SourceLanguage { get; set; }
+
+        public CultureCode TargetLanguage { get; set; }
+    }
+}

--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.8.0")]
+[assembly: AssemblyFileVersion("7.0.8.1")]

--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Studio/DeepLMtTranslationProvider.cs
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Studio/DeepLMtTranslationProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using NLog;
+using Sdl.Community.DeepLMTProvider.Interface;
 using Sdl.Community.DeepLMTProvider.Client;
 using Sdl.Community.DeepLMTProvider.Model;
 using Sdl.LanguagePlatform.Core;
@@ -8,7 +10,7 @@ using Sdl.LanguagePlatform.TranslationMemoryApi;
 
 namespace Sdl.Community.DeepLMTProvider.Studio
 {
-    public class DeepLMtTranslationProvider : ITranslationProvider
+    public class DeepLMtTranslationProvider : ITranslationProvider, ITranslationProviderExtension
     {
         public static readonly string ListTranslationProviderScheme = "deepltranslationprovider";
         private readonly Logger _logger = Log.GetLogger(nameof(Client.DeepLTranslationProviderClient));
@@ -22,6 +24,8 @@ namespace Sdl.Community.DeepLMTProvider.Studio
             {
                 GetSupportedTargetLanguages(languagePairs);
             }
+
+            LanguagesSupported = Options.LanguagesSupported;
         }
 
         public bool IsReadOnly => true;
@@ -53,6 +57,8 @@ namespace Sdl.Community.DeepLMTProvider.Studio
         public TranslationMethod TranslationMethod => TranslationMethod.MachineTranslation;
         public Uri Uri => Options.Uri;
         public DeepLTranslationProviderClient DeepLTranslationProviderConnecter { get; }
+
+        public Dictionary<string, string> LanguagesSupported { get; set; } = new Dictionary<string, string>();
 
         public ITranslationProviderLanguageDirection GetLanguageDirection(LanguagePair languageDirection)
         {

--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Studio/DeepLMtTranslationProviderLanguageDirection.cs
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/Studio/DeepLMtTranslationProviderLanguageDirection.cs
@@ -166,7 +166,7 @@ namespace Sdl.Community.DeepLMTProvider.Studio
         {
             var tu = new TranslationUnit
             {
-                SourceSegment = segment.Duplicate(),//this makes the original source segment, with tags, appear in the search window
+                SourceSegment = segment.Duplicate(),
                 TargetSegment = translation
             };
 
@@ -244,8 +244,14 @@ namespace Sdl.Community.DeepLMTProvider.Studio
                 {
                     var newSeg = segment.TranslationUnit.SourceSegment.Duplicate();
 
-                    var sourceText = ApplyBeforeTranslationSettings(newSeg);
+                    if (segment.TranslationUnit.TargetSegment != null)
+                    {
+                        var tarSeg = segment.TranslationUnit.TargetSegment.Duplicate();
+                        var targetText = ApplyBeforeTranslationSettings(tarSeg);
+                        segment.PlainTranslation = targetText;
+                    }
 
+                    var sourceText = ApplyBeforeTranslationSettings(newSeg);
                     segment.SourceText = sourceText;
                 }
 
@@ -253,8 +259,11 @@ namespace Sdl.Community.DeepLMTProvider.Studio
                 {
                     if (segment == null) return;
 
-                    var plainTranslation = LookupDeepL(segment.SourceText);
-                    segment.PlainTranslation = plainTranslation;
+                    if (segment.TranslationUnit.ConfirmationLevel == ConfirmationLevel.Unspecified)
+                    {
+                        var plainTranslation = LookupDeepL(segment.SourceText);
+                        segment.PlainTranslation = plainTranslation;
+                    }
                 });
 
                 return preTranslateSegments;

--- a/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
+++ b/DeepL Translation Provider/Sdl.Community.DeelLMTProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>DeepL Translation Provider</PlugInName>
-	<Version>7.0.8.0</Version>
+	<Version>7.0.8.1</Version>
 	<Description>This plugin provides machine translation results from the DeepL Translator.</Description>
 	<Author>Trados AppStore Team</Author>
 	<RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />


### PR DESCRIPTION
- Replaced the generated translation with the cached version if the segment has already been translated.
- Added support for the ITranslationProviderExtension interface to ensure compatibility with the MT Comparison Tool (SDLCOM-6521).