### PR TITLE
Google Cloud Translation Provider 2.0.2.0 - SDLCOM-6493:

### DIFF
--- a/Google Cloud Translation Provider/GoogleCloudTranslationProvider.csproj
+++ b/Google Cloud Translation Provider/GoogleCloudTranslationProvider.csproj
@@ -44,6 +44,9 @@
     <Reference Include="NLog">
       <HintPath>$(TradosFolder)\NLog.dll</HintPath>
     </Reference>
+	<Reference Include="Sdl.FileTypeSupport.Framework.Core">
+		<HintPath>$(TradosFolder)\Sdl.FileTypeSupport.Framework.Core.dll</HintPath>
+	</Reference>
     <Reference Include="Sdl.Core.Globalization">
       <HintPath>$(TradosFolder)\Sdl.Core.Globalization.dll</HintPath>
     </Reference>

--- a/Google Cloud Translation Provider/Interface/ITranslationProviderExtension.cs
+++ b/Google Cloud Translation Provider/Interface/ITranslationProviderExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudTranslationProvider.Interface
+{
+    public interface ITranslationProviderExtension
+    {
+        Dictionary<string, string> LanguagesSupported { get; set; }
+    }
+}

--- a/Google Cloud Translation Provider/PluginResources.Designer.cs
+++ b/Google Cloud Translation Provider/PluginResources.Designer.cs
@@ -414,6 +414,15 @@ namespace GoogleCloudTranslationProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Google Translate.
+        /// </summary>
+        public static string LanguageSupported_ShortName {
+            get {
+                return ResourceManager.GetString("LanguageSupported_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string LMP_Button_ApplyChanges {

--- a/Google Cloud Translation Provider/PluginResources.resx
+++ b/Google Cloud Translation Provider/PluginResources.resx
@@ -572,4 +572,7 @@ This action cannot be undone.</value>
   <data name="information_48" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\information-48.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="LanguageSupported_ShortName" xml:space="preserve">
+    <value>Google Translate</value>
+  </data>
 </root>

--- a/Google Cloud Translation Provider/Properties/AssemblyInfo.cs
+++ b/Google Cloud Translation Provider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
+[assembly: AssemblyFileVersion("2.0.3.0")]

--- a/Google Cloud Translation Provider/Studio/TranslationProvider.cs
+++ b/Google Cloud Translation Provider/Studio/TranslationProvider.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using GoogleCloudTranslationProvider.Extensions;
 using GoogleCloudTranslationProvider.GoogleAPI;
 using GoogleCloudTranslationProvider.Helpers;
+using GoogleCloudTranslationProvider.Interface;
 using GoogleCloudTranslationProvider.Interfaces;
 using GoogleCloudTranslationProvider.Models;
 using Newtonsoft.Json;
@@ -10,7 +13,7 @@ using Sdl.LanguagePlatform.TranslationMemoryApi;
 
 namespace GoogleCloudTranslationProvider.Studio
 {
-	public class TranslationProvider : ITranslationProvider
+    public class TranslationProvider : ITranslationProvider, ITranslationProviderExtension
 	{
 		private readonly HtmlUtil _htmlUtil;
 
@@ -21,7 +24,8 @@ namespace GoogleCloudTranslationProvider.Studio
 		{
 			Options = options;
 			_htmlUtil = new HtmlUtil();
-		}
+            LanguagesSupported = Options.LanguagesSupported.ToDictionary(lang => lang, lang => PluginResources.LanguageSupported_ShortName);
+        }
 
 		public ITranslationOptions Options { get; set; }
 
@@ -67,7 +71,9 @@ namespace GoogleCloudTranslationProvider.Studio
 
 		public Uri Uri => Options.Uri;
 
-		public bool SupportsLanguageDirection(LanguagePair languageDirection)
+        public Dictionary<string, string> LanguagesSupported { get; set; }
+
+        public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{
 			DatabaseExtensions.CreateDatabase(Options);
 			if (Options.SelectedGoogleVersion is not ApiVersion.V2)

--- a/Google Cloud Translation Provider/pluginpackage.manifest.xml
+++ b/Google Cloud Translation Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Google Cloud Translation Provider</PlugInName>
-  <Version>2.0.2.0</Version>
+  <Version>2.0.3.0</Version>
   <Description>Google Cloud Translation Provider</Description>
   <Author>Trados AppStore Team</Author>
   <RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />


### PR DESCRIPTION
- Updated logic to use the cached translation if the segment was previously translated.
- Integrated support for the ITranslationProviderExtension interface to maintain compatibility with the MT Comparison Tool (SDLCOM-6523).