### PR TITLE
Google Cloud Translation Provider 1.2.2.0 - SDLCOM-6493:

### DIFF
--- a/GoogleCloudTranslationProvider/Interface/ITranslationProviderExtension.cs
+++ b/GoogleCloudTranslationProvider/Interface/ITranslationProviderExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudTranslationProvider.Interface
+{
+	public interface ITranslationProviderExtension
+	{
+		Dictionary<string, string> LanguagesSupported { get; set; }
+	}
+}

--- a/GoogleCloudTranslationProvider/PluginResources.Designer.cs
+++ b/GoogleCloudTranslationProvider/PluginResources.Designer.cs
@@ -414,6 +414,15 @@ namespace GoogleCloudTranslationProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Google Translate.
+        /// </summary>
+        public static string LanguageSupported_ShortName {
+            get {
+                return ResourceManager.GetString("LanguageSupported_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string LMP_Button_ApplyChanges {

--- a/GoogleCloudTranslationProvider/PluginResources.resx
+++ b/GoogleCloudTranslationProvider/PluginResources.resx
@@ -572,4 +572,7 @@ This action cannot be undone.</value>
   <data name="information_48" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\information-48.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="LanguageSupported_ShortName" xml:space="preserve">
+    <value>Google Translate</value>
+  </data>
 </root>

--- a/GoogleCloudTranslationProvider/Properties/AssemblyInfo.cs
+++ b/GoogleCloudTranslationProvider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.1.1")]
+[assembly: AssemblyFileVersion("1.2.2.0")]

--- a/GoogleCloudTranslationProvider/Studio/TranslationProvider.cs
+++ b/GoogleCloudTranslationProvider/Studio/TranslationProvider.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using GoogleCloudTranslationProvider.Extensions;
 using GoogleCloudTranslationProvider.GoogleAPI;
 using GoogleCloudTranslationProvider.Helpers;
+using GoogleCloudTranslationProvider.Interface;
 using GoogleCloudTranslationProvider.Interfaces;
 using GoogleCloudTranslationProvider.Models;
 using Newtonsoft.Json;
@@ -10,7 +13,7 @@ using Sdl.LanguagePlatform.TranslationMemoryApi;
 
 namespace GoogleCloudTranslationProvider.Studio
 {
-	public class TranslationProvider : ITranslationProvider
+	public class TranslationProvider : ITranslationProvider, ITranslationProviderExtension
 	{
 		private readonly HtmlUtil _htmlUtil;
 
@@ -21,6 +24,7 @@ namespace GoogleCloudTranslationProvider.Studio
 		{
 			Options = options;
 			_htmlUtil = new HtmlUtil();
+			LanguagesSupported = Options.LanguagesSupported.ToDictionary(lang => lang, lang => PluginResources.LanguageSupported_ShortName);
 		}
 
 		public ITranslationOptions Options { get; set; }
@@ -66,6 +70,8 @@ namespace GoogleCloudTranslationProvider.Studio
 		public TranslationMethod TranslationMethod => TranslationMethod.MachineTranslation;
 
 		public Uri Uri => Options.Uri;
+
+		public Dictionary<string, string> LanguagesSupported { get; set; } = new Dictionary<string, string>();
 
 		public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{

--- a/GoogleCloudTranslationProvider/pluginpackage.manifest.xml
+++ b/GoogleCloudTranslationProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Google Cloud Translation Provider</PlugInName>
-  <Version>1.2.1.1</Version>
+  <Version>1.2.2.0</Version>
   <Description>Google Cloud Translation Provider</Description>
   <Author>Trados AppStore Team</Author>
   <RequiredProduct name="TradosStudio" minversion="17.2" maxversion="17.9" />


### PR DESCRIPTION
- Integrated support for the ITranslationProviderExtension interface to maintain compatibility with the MT Comparison Tool (SDLCOM-6523).