### PR TITLE
Language Weaver Provider 2.0.6.0 - SDLCOM-6495:

### DIFF
--- a/Language Weaver Provider/PluginResources.Designer.cs
+++ b/Language Weaver Provider/PluginResources.Designer.cs
@@ -520,6 +520,24 @@ namespace LanguageWeaverProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Language Weaver Cloud.
+        /// </summary>
+        public static string LCCloud_ShortName {
+            get {
+                return ResourceManager.GetString("LCCloud_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Language Weaver Edge.
+        /// </summary>
+        public static string LCEdge_ShortName {
+            get {
+                return ResourceManager.GetString("LCEdge_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string LMPView_Buttons_ApplyChanges {

--- a/Language Weaver Provider/PluginResources.resx
+++ b/Language Weaver Provider/PluginResources.resx
@@ -270,6 +270,12 @@
   <data name="FeedbackView_Title" xml:space="preserve">
     <value>Give feedback!</value>
   </data>
+  <data name="LCCloud_ShortName" xml:space="preserve">
+    <value>Language Weaver Cloud</value>
+  </data>
+  <data name="LCEdge_ShortName" xml:space="preserve">
+    <value>Language Weaver Edge</value>
+  </data>
   <data name="LMPViewModel_ResetTitle" xml:space="preserve">
     <value>Reset to default</value>
   </data>

--- a/Language Weaver Provider/Properties/AssemblyInfo.cs
+++ b/Language Weaver Provider/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.5.1")]
+[assembly: AssemblyFileVersion("2.0.6.0")]

--- a/Language Weaver Provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
+++ b/Language Weaver Provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
@@ -205,18 +205,19 @@ namespace LanguageWeaverProvider
 		private SearchResults CreateDraftNotResentSearchResults(Segment segment)
 		{
 			var targetSegment = new Segment(_languagePair.TargetCulture);
-			targetSegment.Add(PluginResources.TranslationDraftNotResent);
 
 			var searchResults = new SearchResults { SourceSegment = segment.Duplicate() };
-            var tuSearchResult = CreateTuSearchResult(segment, targetSegment);
+            return searchResults;
+			//targetSegment.Add(PluginResources.TranslationDraftNotResent);
+   //         var tuSearchResult = CreateTuSearchResult(segment, targetSegment);
 
-            searchResults.Add(new SearchResult(tuSearchResult)
-            {
-                ScoringResult = new ScoringResult { BaseScore = 0 },
-                TranslationProposal = new TranslationUnit(tuSearchResult)
-            });
+   //         searchResults.Add(new SearchResult(tuSearchResult)
+   //         {
+   //             ScoringResult = new ScoringResult { BaseScore = 0 },
+   //             TranslationProposal = new TranslationUnit(tuSearchResult)
+   //         });
 
-			return searchResults;
+			//return searchResults;
 		}
 
 		private Segment GetSourceSegment(Segment segment)

--- a/Language Weaver Provider/pluginpackage.manifest.xml
+++ b/Language Weaver Provider/pluginpackage.manifest.xml
@@ -5,7 +5,7 @@
 	<PlugInName>Language Weaver Provider</PlugInName>
 	<Description>Language Weaver Provider</Description>
 	
-	<Version>2.0.5.1</Version>
+	<Version>2.0.6.0</Version>
 	<RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />
 
 	<Include>


### PR DESCRIPTION
- Enhanced the Resend Draft feature to return an empty result when the segment is already translated.
- Added support for the ITranslationProviderExtension interface to ensure compatibility with the MT Comparison Tool (SDLCOM-6524).