### PR TITLE
Google Cloud Translation Provider 2.0.3.0 - SDLCOM-6493:

### DIFF
--- a/Google Cloud Translation Provider/Studio/TranslationProviderLanguageDirection.cs
+++ b/Google Cloud Translation Provider/Studio/TranslationProviderLanguageDirection.cs
@@ -69,17 +69,10 @@ namespace GoogleCloudTranslationProvider.Studio
             var searchResults = new SearchResults { SourceSegment = segment.Duplicate() };
 
 
-            if (TryGetCachedTranslation(_currentTranslationUnit, out var cachedResult))
+            if (!_translationOptions.ResendDrafts && _currentTranslationUnit.ConfirmationLevel != ConfirmationLevel.Unspecified)
             {
-                return cachedResult;
+                return searchResults;
             }
-
-            //if (!_translationOptions.ResendDrafts && _currentTranslationUnit.ConfirmationLevel != ConfirmationLevel.Unspecified)
-            //{
-            //	translation.Add(PluginResources.TranslationLookupDraftNotResentMessage);
-            //	searchResults.Add(CreateSearchResult(segment, translation));
-            //	return searchResults;
-            //}
 
             var newSegment = segment.Duplicate();
             if (_translationOptions.SendPlainTextOnly || !newSegment.HasTags)
@@ -251,29 +244,6 @@ namespace GoogleCloudTranslationProvider.Studio
 
 			return _googleV2Api.Translate(_languageDirection, sourcetext, format);
 		}
-
-        private bool TryGetCachedTranslation(TranslationUnit translationUnit, out SearchResults result)
-        {
-            result = new SearchResults()
-            {
-                SourceSegment = translationUnit.SourceSegment
-            };
-            if (!_translationOptions.ResendDrafts &&
-                translationUnit.ConfirmationLevel != ConfirmationLevel.Unspecified)
-            {
-                var segmentPair = translationUnit.DocumentSegmentPair;
-                var translationOrigin = segmentPair.Properties.TranslationOrigin;
-                if (translationOrigin.OriginSystem == _provider.Name)
-                {
-                    result.Add(CreateSearchResult(translationUnit.SourceSegment.Duplicate(), translationUnit.TargetSegment.Duplicate()));
-                    return true;
-                }
-
-                return false;
-            }
-
-            return false;
-        }
         #region Unused
         /// <summary>
         /// Not required for this implementation.

--- a/Google Cloud Translation Provider/ViewModel/MainWindowViewModel.cs
+++ b/Google Cloud Translation Provider/ViewModel/MainWindowViewModel.cs
@@ -207,6 +207,8 @@ namespace GoogleCloudTranslationProvider.ViewModels
 
         private bool IsSaveEnabled(object obj)
         {
+            if (SelectedView.ViewModel is SettingsViewModel) return true;
+
             if (SelectedView.ViewModel is not ProviderViewModel providerViewModel) return false;
             if (!providerViewModel.IsV3Checked) return !string.IsNullOrWhiteSpace(providerViewModel.ApiKey);
 

--- a/Google Cloud Translation Provider/ViewModel/SettingsViewModel.cs
+++ b/Google Cloud Translation Provider/ViewModel/SettingsViewModel.cs
@@ -205,7 +205,7 @@ namespace GoogleCloudTranslationProvider.ViewModels
 			}
 		}
 
-		public ICommand ClearCommand => _clearCommand ??= new RelayCommand(Clear);
+        public ICommand ClearCommand => _clearCommand ??= new RelayCommand(Clear);
 
 		public ICommand BrowseFileCommand => _browseFileCommand ??= new RelayCommand(BrowseFile);
 


### PR DESCRIPTION
- Updated the provider to return an empty result when the segment is already translated.
- Fixed the MainWindow to allow confirmation when the current view model is Settings.