### PR TITLE
Microsoft Translator Provider 2.0.7.0 - SDLCOM-6494:

### DIFF
--- a/Microsoft Translator Provider/Interface/ITranslationProviderExtension.cs
+++ b/Microsoft Translator Provider/Interface/ITranslationProviderExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MicrosoftTranslatorProvider.Interface
+{
+    public interface ITranslationProviderExtension
+    {
+        Dictionary<string, string> LanguagesSupported { get; set; }
+    }
+}

--- a/Microsoft Translator Provider/Model/PairModel.cs
+++ b/Microsoft Translator Provider/Model/PairModel.cs
@@ -8,7 +8,7 @@ namespace MicrosoftTranslatorProvider.Model
 {
 	public class PairModel : BaseViewModel
     {
-		ICommand _clearCommand;
+		//ICommand _clearCommand;
 
 		string _sourceLanguageCode;
 		string _targetLanguageCode;
@@ -54,7 +54,7 @@ namespace MicrosoftTranslatorProvider.Model
 			}
 		}
 
-		public ICommand ClearCommand => _clearCommand ??= new RelayCommand(Clear);
+		public ICommand ClearCommand => new RelayCommand(Clear);
 
 		public PairModel Clone()
 		{

--- a/Microsoft Translator Provider/PluginResources.Designer.cs
+++ b/Microsoft Translator Provider/PluginResources.Designer.cs
@@ -308,6 +308,15 @@ namespace MicrosoftTranslatorProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Microsoft Translator.
+        /// </summary>
+        public static string Microsoft_ShortName {
+            get {
+                return ResourceManager.GetString("Microsoft_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Microsoft Translator Provider.
         /// </summary>
         public static string Microsoft_Tooltip {

--- a/Microsoft Translator Provider/PluginResources.resx
+++ b/Microsoft Translator Provider/PluginResources.resx
@@ -382,4 +382,7 @@ It must be the same region you selected when you signed up for your multi-servic
   <data name="TellMe_ThirdParty" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\TellMe_ThirdParty.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="Microsoft_ShortName" xml:space="preserve">
+    <value>Microsoft Translator</value>
+  </data>
 </root>

--- a/Microsoft Translator Provider/Properties/AssemblyInfo.cs
+++ b/Microsoft Translator Provider/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.6.0")]
+[assembly: AssemblyFileVersion("2.0.7.0")]

--- a/Microsoft Translator Provider/Studio/TranslationProvider/TranslationProvider.cs
+++ b/Microsoft Translator Provider/Studio/TranslationProvider/TranslationProvider.cs
@@ -6,15 +6,16 @@ using MicrosoftTranslatorProvider.Model;
 using Newtonsoft.Json;
 using Sdl.LanguagePlatform.Core;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
+using MicrosoftTranslatorProvider.Interface;
 
 namespace MicrosoftTranslatorProvider
 {
-	public class TranslationProvider : ITranslationProvider
+    public class TranslationProvider : ITranslationProvider, ITranslationProviderExtension
 	{
-
-		public TranslationProvider(ITranslationOptions translationOptions)
+        public TranslationProvider(ITranslationOptions translationOptions)
 		{
 			TranslationOptions = translationOptions;
+			SetSupportedLanguages();
 		}
 
 		public string Name => TranslationOptions.ProviderName;
@@ -63,7 +64,9 @@ namespace MicrosoftTranslatorProvider
 
 		public bool SupportsWordCounts => false;
 
-		public bool SupportsLanguageDirection(LanguagePair languageDirection)
+        public Dictionary<string, string> LanguagesSupported { get; set; } = new Dictionary<string, string>();
+
+        public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{
 			if (TranslationOptions.AuthenticationType == AuthenticationType.PrivateEndpoint)
 			{
@@ -98,5 +101,25 @@ namespace MicrosoftTranslatorProvider
 		}
 
 		public void RefreshStatusInfo() { }
+
+		private void SetSupportedLanguages()
+		{
+			var options = TranslationOptions;
+			var pairModels = options.PairModels;
+			var name = PluginResources.Microsoft_ShortName;
+
+            foreach (var pairModel in pairModels)
+            {
+				var languagePair = pairModel.TradosLanguagePair;
+                var targetLanguage = languagePair.TargetCulture.RegionNeutralName.ToUpper();
+                if (!LanguagesSupported.ContainsKey(targetLanguage))
+                {
+                    if (!LanguagesSupported.ContainsKey(languagePair.TargetCultureName))
+                    {
+                        LanguagesSupported.Add(languagePair.TargetCultureName, name);
+                    }
+                }
+            }
+        }
 	}
 }

--- a/Microsoft Translator Provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
+++ b/Microsoft Translator Provider/Studio/TranslationProvider/TranslationProviderLanguageDirection.cs
@@ -54,8 +54,6 @@ namespace MicrosoftTranslatorProvider
 			var searchResults = new SearchResults { SourceSegment = segment.Duplicate() };
 			if (!_translationOptions.ProviderSettings.ResendDrafts && _currentTranslationUnit.ConfirmationLevel != ConfirmationLevel.Unspecified)
 			{
-				translation.Add(PluginResources.TranslationLookupDraftNotResentMessage);
-				searchResults.Add(CreateSearchResult(segment, translation));
 				return searchResults;
 			}
 

--- a/Microsoft Translator Provider/View/MicrosoftConfigurationView.xaml
+++ b/Microsoft Translator Provider/View/MicrosoftConfigurationView.xaml
@@ -73,7 +73,7 @@
 								<Button Content="Update"
 										Style="{StaticResource TransparentButtonStyle}"
 										Command="{Binding ResetAndIdentifyPairsCommand}"
-                                        IsEnabled="{Binding ConfigureLanguages}"
+                                        IsEnabled="{Binding TranslationOptions.ProviderSettings.ConfigureLanguages}"
                                         CommandParameter="Update"
                                         Foreground="#FF008080"
 										FontWeight="DemiBold"
@@ -88,7 +88,7 @@
 								<Button Content="Reset to default"
 										Style="{StaticResource TransparentButtonStyle}"
 										Command="{Binding ResetAndIdentifyPairsCommand}"
-                                        IsEnabled="{Binding ConfigureLanguages}"
+                                        IsEnabled="{Binding TranslationOptions.ProviderSettings.ConfigureLanguages}"
                                         CommandParameter="Reset to default"
                                         Foreground="#FF008080"
 										FontWeight="DemiBold"
@@ -103,7 +103,7 @@
 								  ItemsSource="{Binding PairModels}"
 								  Background="#ffffff"
 								  AlternationCount="2"
-                                  IsEnabled="{Binding ConfigureLanguages}"
+                                  IsEnabled="{Binding TranslationOptions.ProviderSettings.ConfigureLanguages}"
                                   Focusable="False">
 						<ItemsControl.ItemTemplate>
 							<DataTemplate>
@@ -167,7 +167,7 @@
 													 AutomationProperties.Name="Category ID"
 													 Text="{Binding Model, UpdateSourceTrigger=PropertyChanged}"
 													 Style="{StaticResource WatermarkTextBox}"
-                                                     IsEnabled="{Binding ConfigureLanguages}"
+                                                     IsEnabled="{Binding TranslationOptions.ProviderSettings.ConfigureLanguages}"
                                                      controls:WatermarkTextBox.WatermarkText="Category ID..."
 													 controls:WatermarkTextBox.ButtonCommand="{Binding ClearCommand}"
 													 controls:WatermarkTextBox.ButtonCommandParameter="{controls:NameOf Member=Model, Type={x:Type models:PairModel}}"
@@ -234,7 +234,7 @@
 										BorderThickness="0 1 1 0"
 										Height="24"
 										Padding="4 0">
-									<TextBlock Text="Target"
+									<TextBlock Text="Source"
 											   VerticalAlignment="Center"
 											   FontWeight="DemiBold"
 											   FontSize="11" />
@@ -246,7 +246,7 @@
 										BorderThickness="0 1 1 0"
 										Height="24"
 										Padding="4 0">
-									<TextBlock Text="Source"
+									<TextBlock Text="Target"
 											   VerticalAlignment="Center"
 											   FontWeight="DemiBold"
 											   FontSize="11" />

--- a/Microsoft Translator Provider/ViewModel/MicrosoftConfigurationViewModel.cs
+++ b/Microsoft Translator Provider/ViewModel/MicrosoftConfigurationViewModel.cs
@@ -31,7 +31,7 @@ namespace MicrosoftTranslatorProvider.ViewModel
 
 		public ITranslationOptions TranslationOptions { get; private set; }
 
-        public ObservableCollection<PairModel> PairModels { get; private set; }
+        public ObservableCollection<PairModel> PairModels { get; private set; } = new ObservableCollection<PairModel>();
 
 		public string LoadingAction
 		{

--- a/Microsoft Translator Provider/pluginpackage.manifest.xml
+++ b/Microsoft Translator Provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Microsoft Translator Provider</PlugInName>
-  <Version>2.0.6.0</Version>
+  <Version>2.0.7.0</Version>
   <Description>Microsoft Translator Provider</Description>
   <Author>Trados AppStore Team</Author>
   <RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />


### PR DESCRIPTION
- Removed the Hardcoded translation result message
- Enabled Category ID removal
- Updated the source and target languages column in the configuration view
- Added support for the ITranslationProviderExtension interface to ensure compatibility with the MT Comparison Tool