### PR TITLE
Microsoft Translator Provider 1.2.4.0 - SDLCOM-6527:

### DIFF
--- a/MicrosoftTranslatorProvider/Interface/ITranslationProviderExtension.cs
+++ b/MicrosoftTranslatorProvider/Interface/ITranslationProviderExtension.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace MicrosoftTranslatorProvider.Interface
+{
+    public interface ITranslationProviderExtension
+    {
+        Dictionary<string, string> LanguagesSupported { get; set; }
+    }
+}

--- a/MicrosoftTranslatorProvider/PluginResources.Designer.cs
+++ b/MicrosoftTranslatorProvider/PluginResources.Designer.cs
@@ -308,6 +308,15 @@ namespace MicrosoftTranslatorProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Microsoft Translator.
+        /// </summary>
+        public static string Microsoft_ShortName {
+            get {
+                return ResourceManager.GetString("Microsoft_ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Microsoft Translator Provider.
         /// </summary>
         public static string Microsoft_Tooltip {

--- a/MicrosoftTranslatorProvider/PluginResources.resx
+++ b/MicrosoftTranslatorProvider/PluginResources.resx
@@ -359,4 +359,7 @@ It must be the same region you selected when you signed up for your multi-servic
   <data name="mstp_icon" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\mstp-icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="Microsoft_ShortName" xml:space="preserve">
+    <value>Microsoft Translator</value>
+  </data>
 </root>

--- a/MicrosoftTranslatorProvider/Properties/AssemblyInfo.cs
+++ b/MicrosoftTranslatorProvider/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.3.0")]
+[assembly: AssemblyFileVersion("1.2.4.0")]

--- a/MicrosoftTranslatorProvider/Studio/TranslationProvider/Provider.cs
+++ b/MicrosoftTranslatorProvider/Studio/TranslationProvider/Provider.cs
@@ -1,25 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MicrosoftTranslatorProvider.Extensions;
 using MicrosoftTranslatorProvider.Interfaces;
 using MicrosoftTranslatorProvider.Model;
 using MicrosoftTranslatorProvider.Studio.TranslationProvider;
+using MicrosoftTranslatorProvider.Interface;
 using Newtonsoft.Json;
 using Sdl.LanguagePlatform.Core;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
 
 namespace MicrosoftTranslatorProvider
 {
-	public class Provider : ITranslationProvider
+    public class Provider : ITranslationProvider, ITranslationProviderExtension
 	{
 		private MicrosoftApi _providerConnector;
 
 		public Provider(ITranslationOptions options)
 		{
 			Options = options;
-		}
+            LanguagesSupported = Options.LanguagesSupported.ToDictionary(lang => lang, lang => PluginResources.Microsoft_ShortName);
+        }
 
-		public string Name
+        public string Name
 		{
 			get
 			{
@@ -76,7 +79,9 @@ namespace MicrosoftTranslatorProvider
 
 		public bool SupportsWordCounts => false;
 
-		public bool SupportsLanguageDirection(LanguagePair languageDirection)
+        public Dictionary<string, string> LanguagesSupported { get; set; } = new Dictionary<string, string>();
+
+        public bool SupportsLanguageDirection(LanguagePair languageDirection)
 		{
 			if (Options.UsePrivateEndpoint)
 			{

--- a/MicrosoftTranslatorProvider/pluginpackage.manifest.xml
+++ b/MicrosoftTranslatorProvider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Microsoft Translator Provider</PlugInName>
-  <Version>1.2.3.0</Version>
+  <Version>1.2.4.0</Version>
   <Description>Microsoft Translator Provider</Description>
   <Author>Trados AppStore Team</Author>
   <RequiredProduct name="TradosStudio" minversion="17.2" maxversion="17.9" />


### PR DESCRIPTION
- Added support for the ITranslationProviderExtension interface to ensure compatibility with the MT Comparison Tool