### PR TITLE
Post-Edit Compare - SDLCOM-6481: Detect deletions with tracked changes

### DIFF
--- a/Post-Edit Compare/Build/SolutionInfo.cs
+++ b/Post-Edit Compare/Build/SolutionInfo.cs
@@ -17,4 +17,4 @@
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("8.0.0.0")]
-[assembly: AssemblyFileVersion("8.0.5.67")]
+[assembly: AssemblyFileVersion("8.0.5.69")]

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Comparison/Comparer.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Comparison/Comparer.cs
@@ -348,10 +348,11 @@ namespace Sdl.Community.PostEdit.Compare.Core.Comparison
 
             AddTmTuMetadata(comparisonSegmentUnit, segmentPairOriginal, segmentPairUpdated);
 
-            if (string.CompareOrdinal(segmentPairOriginal.Target, segmentPairUpdated.Target) != 0)
+            if (string.CompareOrdinal(segmentPairOriginal.Target, segmentPairUpdated.Target) != 0 ||
+                !segmentPairOriginal.TargetSections.SequenceEqual(segmentPairUpdated.TargetSections))
             {
-                comparisonSegmentUnit.ComparisonTextUnits = GetComparisonTextUnits(segmentPairOriginal.TargetSections, segmentPairUpdated.TargetSections);
-
+                comparisonSegmentUnit.ComparisonTextUnits = GetComparisonTextUnits(segmentPairOriginal.TargetSections,
+                    segmentPairUpdated.TargetSections);
                 comparisonSegmentUnit.SegmentTextUpdated = true;
                 comparisonParagraphUnit.ParagraphIsUpdated = true;
             }

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Reports/PostEdit.Compare.Report.01.xslt
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Reports/PostEdit.Compare.Report.01.xslt
@@ -546,7 +546,7 @@
     <xsl:variable name="showSegmentTerp" select="filter/@showSegmentTerp"/>
     <xsl:variable name="showSegmentPemp" select="filter/@showSegmentPemp"/>
 
-    <a name="filesId_report_header"> </a>
+    <a name="filesId_report_header" data-project-id='{@projectId}'> </a>
 
     <table style="background-color: #CEE3F6" border="1" width="100%">
       <tr>

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Reports/Report.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/Reports/Report.cs
@@ -333,6 +333,12 @@ namespace Sdl.Community.PostEdit.Compare.Core.Reports
             xmlTxtWriter.WriteAttributeString("totalFilesWithErrors", (fileComparisonFileParagraphUnits.Count - progressFilesCompared).ToString());
             xmlTxtWriter.WriteAttributeString("dateCompared", DateTime.Now.ToLongDateString() + ", " + DateTime.Now.ToLongTimeString());
 
+            var projectFilePath = fileComparisonFileParagraphUnits.FirstOrDefault().Key.FilePathOriginal;
+            if (!string.IsNullOrWhiteSpace(projectFilePath))
+            {
+                var originalProjectId = FileIdentifier.GetProjectId(projectFilePath);
+                xmlTxtWriter.WriteAttributeString("projectId", originalProjectId);
+            }
 
             xmlTxtWriter.WriteStartElement("filter");
 

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/SDLXLIFF/SegmentSection.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Core/SDLXLIFF/SegmentSection.cs
@@ -1,12 +1,13 @@
-﻿namespace Sdl.Community.PostEdit.Compare.Core.SDLXLIFF
+﻿using System;
+
+namespace Sdl.Community.PostEdit.Compare.Core.SDLXLIFF
 {
-    public class SegmentSection
+    public class SegmentSection : IEquatable<SegmentSection>
     {
         public ContentType Type { get; set; }
         public string Content { get; set; }
         public string SectionId { get; set; }
         public RevisionMarker RevisionMarker { get; set; }
-
 
         public SegmentSection(ContentType type, string sectionId, string content)
         {
@@ -24,8 +25,6 @@
             RevisionMarker = revisionMarker;
         }
 
-
-
         public enum ContentType
         {
             Text = 0,
@@ -33,6 +32,37 @@
             TagClosing,
             Placeholder,
             LockedContent
+        }
+
+        public bool Equals(SegmentSection other)
+        {
+            if (other == null)
+                return false;
+
+            return Type == other.Type &&
+                   Content == other.Content &&
+                   SectionId == other.SectionId &&
+                   ((RevisionMarker == null && other.RevisionMarker == null) ||
+                    (RevisionMarker != null && other.RevisionMarker != null &&
+                     RevisionMarker.Author == other.RevisionMarker.Author &&
+                     RevisionMarker.Date == other.RevisionMarker.Date &&
+                     RevisionMarker.Type == other.RevisionMarker.Type));
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SegmentSection);
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = Type.GetHashCode();
+            hash = (hash * 397) ^ (Content?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (SectionId?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (RevisionMarker?.Author?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (RevisionMarker?.Date.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (RevisionMarker?.Type.GetHashCode() ?? 0);
+            return hash;
         }
     }
 }

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/Integration.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/Integration.cs
@@ -158,7 +158,7 @@ public class Integration
     public static void OpenReportBackupFolder()
     {
         var selectedReport = ReportViewController.GetSelectedReport();
-        ReportManager.OpenReportBackupFolder(selectedReport);
+        ReportManager.OpenReportBackupFolder(selectedReport?.ReportPath);
     }
 
     public static void OpenReportFolder()

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportManaging/ReportManager.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportManaging/ReportManager.cs
@@ -137,15 +137,16 @@ namespace Sdl.Community.PostEdit.Versions.HTMLReportIntegration.ReportManaging
             return reports;
         }
 
-        public void OpenReportBackupFolder(ReportInfo selectedReport)
+        public void OpenReportBackupFolder(string reportPath)
         {
-            if (selectedReport is not null)
+            if (!string.IsNullOrWhiteSpace(reportPath))
             {
                 var reportBackupFolder = Path.Combine(PostEditCompareBackupFolder,
-                    Path.GetFileNameWithoutExtension(selectedReport.ReportPath));
+                    Path.GetFileNameWithoutExtension(reportPath));
 
                 if (Directory.Exists(reportBackupFolder)) { Process.Start(reportBackupFolder); return; }
             }
+
             Process.Start(PostEditCompareBackupFolder);
         }
 

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportManaging/ReportManager.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportManaging/ReportManager.cs
@@ -168,11 +168,8 @@ namespace Sdl.Community.PostEdit.Versions.HTMLReportIntegration.ReportManaging
             var doc = new HtmlDocument();
             doc.Load(htmlFilepath);
 
-            var rows = doc.DocumentNode.SelectSingleNode("//tr[@data-project-id]");
-            if (rows == null) return string.Empty;
-
-            var projectIdAttribute = rows.Attributes["data-project-id"];
-            return projectIdAttribute != null ? projectIdAttribute.Value : string.Empty;
+            var node = doc.DocumentNode.SelectSingleNode("//a[@data-project-id]");
+            return node?.GetAttributeValue("data-project-id", string.Empty) ?? string.Empty;
         }
 
         private void CreateDefaultFoldersList()

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportView/ViewModel/ReportExplorerViewModel.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/HTMLReportIntegration/ReportView/ViewModel/ReportExplorerViewModel.cs
@@ -76,6 +76,16 @@ public class ReportExplorerViewModel : ViewModelBase
                 Reports = new ObservableCollection<ReportInfo>(reportsInfo.ToList())
             });
         }
+
+        if (ReportGroups.Sum(g => g.Reports.Count) == reports.Count) return;
+
+        var notGroupedReports = reports.Where(r => ReportGroups.All(g => !g.Reports.Contains(r)));
+
+        ReportGroups.Add(new ReportGroup
+        {
+            ProjectName = "Unlinked reports",
+            Reports = new ObservableCollection<ReportInfo>(notGroupedReports)
+        });
     }
 
     private void ApplyFilter()

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/PostEditCompareViewRibbonGroup.cs
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/PostEditCompareViewRibbonGroup.cs
@@ -260,6 +260,7 @@ namespace Sdl.Community.PostEdit.Versions
             var postEditCompare = new FormMain(mModel);
             postEditCompare.OriginalProjectPath = Controller.CurrentSelectedProject?.FilePath;
             postEditCompare.ShowDialog();
+            if (postEditCompare.Saved) Integration.ShowLatestReport();
         }
     }
 

--- a/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/pluginpackage.manifest.xml
+++ b/Post-Edit Compare/Sdl.Community.PostEdit.Compare.Versions/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
 	<PlugInName>Post-Edit Compare</PlugInName>
-	<Version>8.0.5.67</Version>
+	<Version>8.0.5.69</Version>
 	<Description>Post-Edit Compare</Description>
 	<Author>Trados AppStore Team</Author>
 	<RequiredProduct name="TradosStudio" minversion="18.0" maxversion="18.9" />


### PR DESCRIPTION
Detect deletions with tracked changes <- compare segments not just by text, but also by target sections
+ add projectId in the report header -> less unlinked projects
+ add Unlinked Reports group in report viewer -> all reports are now shown
+ ask user to navigate to latest report from OpenCompare action too