### PR TITLE
Amazon Translate MT provider 5.1.1.0:

### DIFF
--- a/Amazon Translate MT provider/Properties/AssemblyInfo.cs
+++ b/Amazon Translate MT provider/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.1.0.0")]
+[assembly: AssemblyFileVersion("5.1.1.0")]
 

--- a/Amazon Translate MT provider/pluginpackage.manifest.xml
+++ b/Amazon Translate MT provider/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Amazon Translate MT provider</PlugInName>
-  <Version>5.1.0.0</Version>
+  <Version>5.1.1.0</Version>
   <Description>This plugin provides machine translation from the Amazon Translate Service AWS.</Description>
   <Author>Trados AppStore Team</Author>
 	<Include>


### PR DESCRIPTION
- Updated the `AmazonService` class to use `TranslateDocumentRequest` isntead fo `TranslateTextRequest` for improved tag handling.