### PR TITLE
Amazon Translate MT provider 4.2.2.0:

### DIFF
--- a/AmazonTranslateTradosPlugin/Properties/AssemblyInfo.cs
+++ b/AmazonTranslateTradosPlugin/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.2.1.0")]
+[assembly: AssemblyFileVersion("4.2.2.0")]
 

--- a/AmazonTranslateTradosPlugin/Sdl.Community.AmazonTranslateTradosPlugin.csproj
+++ b/AmazonTranslateTradosPlugin/Sdl.Community.AmazonTranslateTradosPlugin.csproj
@@ -70,7 +70,7 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Translate" Version="3.7.4.35" />
+    <PackageReference Include="AWSSDK.Translate" Version="4.0.0.22" />
     <PackageReference Include="Sdl.Core.PluginFramework">
       <Version>2.1.0</Version>
     </PackageReference>

--- a/AmazonTranslateTradosPlugin/pluginpackage.manifest.xml
+++ b/AmazonTranslateTradosPlugin/pluginpackage.manifest.xml
@@ -1,7 +1,7 @@
 
 <PluginPackage xmlns="http://www.sdl.com/Plugins/PluginPackage/1.0">
   <PlugInName>Amazon Translate MT provider</PlugInName>
-  <Version>4.2.1.0</Version>
+  <Version>4.2.2.0</Version>
   <Description>This plugin provides machine translation from the Amazon Translate Service AWS.</Description>
   <Author>Trados AppStore Team</Author>
 	<Include>


### PR DESCRIPTION
- Updated the `AWSSDK.Translate` version
- Updated the `AmazonService` class to use `TranslateDocumentRequest` instead of `TranslateTextRequest` for improved tag handling.