### PR TITLE
Language Weaver Provider 2.1.4.0

### DIFF
--- a/Language Weaver Provider/Properties/AssemblyInfo.cs
+++ b/Language Weaver Provider/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.1.3.0")]
+[assembly: AssemblyFileVersion("2.1.4.0")]

--- a/Language Weaver Provider/Services/CredentialManager.cs
+++ b/Language Weaver Provider/Services/CredentialManager.cs
@@ -14,6 +14,7 @@ namespace LanguageWeaverProvider.Extensions
     {
         private const string CredentialsKey = "credentials";
         private const string TokenKey = "accessToken";
+        private static readonly object _credentialLock = new object();
 
         public static bool CredentialsArePersisted(Uri translationProviderUri)
         {
@@ -158,20 +159,23 @@ namespace LanguageWeaverProvider.Extensions
                 return;
             }
 
-            var credentials = translationOptions.PluginVersion == PluginVersion.LanguageWeaverCloud
-                            ? JsonConvert.SerializeObject(translationOptions.CloudCredentials)
-                            : JsonConvert.SerializeObject(translationOptions.EdgeCredentials);
+            lock (_credentialLock)
+            {
+                var credentials = translationOptions.PluginVersion == PluginVersion.LanguageWeaverCloud
+                                ? JsonConvert.SerializeObject(translationOptions.CloudCredentials)
+                                : JsonConvert.SerializeObject(translationOptions.EdgeCredentials);
 
-            var accessToken = JsonConvert.SerializeObject(translationOptions.AccessToken);
+                var accessToken = JsonConvert.SerializeObject(translationOptions.AccessToken);
 
-            var jsonStructure = new JObject(
-                new JProperty(CredentialsKey, JToken.Parse(credentials)),
-                new JProperty(TokenKey, JToken.Parse(accessToken))
-            ).ToString();
+                var jsonStructure = new JObject(
+                    new JProperty(CredentialsKey, JToken.Parse(credentials)),
+                    new JProperty(TokenKey, JToken.Parse(accessToken))
+                ).ToString();
 
-            var translationProviderCredential = new TranslationProviderCredential(jsonStructure, true);
-            credentialStore.RemoveCredential(translationOptions.Uri);
-            credentialStore.AddCredential(translationOptions.Uri, translationProviderCredential);
+                var translationProviderCredential = new TranslationProviderCredential(jsonStructure, true);
+                credentialStore.RemoveCredential(translationOptions.Uri);
+                credentialStore.AddCredential(translationOptions.Uri, translationProviderCredential);
+            }
         }
     }
 }

--- a/Language Weaver Provider/Services/Service.cs
+++ b/Language Weaver Provider/Services/Service.cs
@@ -39,55 +39,32 @@ namespace LanguageWeaverProvider.Services
             return deserializedObject;
         }
 
-        // we need a sync and an Async method..
+        public static async Task ValidateAndUpdateTokenAsync(ITranslationOptions translationOptions, Action? onValidated)
+        {
+            var result = await ValidateTokenAsync(translationOptions, false);
+            if (result)
+                onValidated?.Invoke();
+        }
 
-        public static bool ValidateToken(ITranslationOptions translationOptions, bool showErrors = true)
-        { 
+        public static async Task<bool> ValidateTokenAsync(ITranslationOptions translationOptions, bool showErrors = true)
+        {
             if (translationOptions.AccessToken is null) return false;
 
-            if (
+            if (true ||
                 translationOptions.AuthenticationType == AuthenticationType.CloudSSO
              && IsTimestampExpired(translationOptions.AccessToken.ExpiresAt))
             {
-                return
-                CloudService
-                    .RefreshAuth0Token(translationOptions)
-                    .GetAwaiter()
-                    .GetResult();
+                return await CloudService.RefreshAuth0Token(translationOptions);
             }
 
             if (translationOptions.PluginVersion == PluginVersion.LanguageWeaverCloud
              && translationOptions.AuthenticationType != AuthenticationType.CloudSSO
              && IsTimestampExpired(translationOptions.AccessToken?.ExpiresAt))
             {
-                return CloudService
-                    .AuthenticateUser(translationOptions, translationOptions.AuthenticationType, showErrors)
-                    .GetAwaiter()
-                    .GetResult();
+                return await CloudService.AuthenticateUser(translationOptions, translationOptions.AuthenticationType, showErrors);
             }
 
             return false;
-        }
-
-        public static async void ValidateTokenAsync(ITranslationOptions translationOptions, bool showErrors = true)
-        {
-            if (translationOptions.AccessToken is null) return;
-
-            if (
-                translationOptions.AuthenticationType == AuthenticationType.CloudSSO
-             && IsTimestampExpired(translationOptions.AccessToken.ExpiresAt))
-            {
-                await CloudService.RefreshAuth0Token(translationOptions);
-                return;
-            }
-
-            if (translationOptions.PluginVersion == PluginVersion.LanguageWeaverCloud
-             && translationOptions.AuthenticationType != AuthenticationType.CloudSSO
-             && IsTimestampExpired(translationOptions.AccessToken?.ExpiresAt))
-            {
-                await CloudService.AuthenticateUser(translationOptions, translationOptions.AuthenticationType, showErrors);
-                return;
-            }
         }
 
         private static bool IsTimestampExpired(double? unixTimeStamp)

--- a/Language Weaver Provider/Services/Service.cs
+++ b/Language Weaver Provider/Services/Service.cs
@@ -50,7 +50,7 @@ namespace LanguageWeaverProvider.Services
         {
             if (translationOptions.AccessToken is null) return false;
 
-            if (true ||
+            if (
                 translationOptions.AuthenticationType == AuthenticationType.CloudSSO
              && IsTimestampExpired(translationOptions.AccessToken.ExpiresAt))
             {

--- a/Language Weaver Provider/Studio/TranslationProvider/TranslationProviderFactory.cs
+++ b/Language Weaver Provider/Studio/TranslationProvider/TranslationProviderFactory.cs
@@ -6,6 +6,7 @@ using LanguageWeaverProvider.WindowsCredentialStore;
 using Newtonsoft.Json;
 using Sdl.LanguagePlatform.TranslationMemoryApi;
 using System;
+using System.Threading.Tasks;
 
 namespace LanguageWeaverProvider
 {
@@ -41,12 +42,7 @@ namespace LanguageWeaverProvider
 
             CredentialManager.GetCredentials(options, true, standaloneCredentials);
 
-            var validated = Service.ValidateToken(options);
-            if (validated)
-            {
-                CredentialManager.UpdateCredentials(credentialStore, options);
-            }
-
+            _ = Service.ValidateAndUpdateTokenAsync(options, () => CredentialManager.UpdateCredentials(credentialStore, options));
             ApplicationInitializer.TranslationOptions[options.Id] = options;
 
             return new TranslationProvider(options);

--- a/Language Weaver Provider/pluginpackage.manifest.xml
+++ b/Language Weaver Provider/pluginpackage.manifest.xml
@@ -5,7 +5,7 @@
 	<PlugInName>Language Weaver Provider</PlugInName>
 	<Description>Language Weaver Provider</Description>
 	
-  <Version>2.1.3.0</Version>
+  <Version>2.1.4.0</Version>
 	<RequiredProduct name="TradosStudio" minversion="18.1" maxversion="18.1.9" />
 
 	<Include>


### PR DESCRIPTION
- Updated `TranslationProvider` factory to call `ValidateAndUpdateTokenAsync` without awaiting
- Fire-and-forget token validation now updates credentials asynchronously