### PR TITLE
Language Weaver Provider 1.0.9.0

### DIFF
--- a/LanguageWeaverProvider/Properties/AssemblyInfo.cs
+++ b/LanguageWeaverProvider/Properties/AssemblyInfo.cs
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")] // Please also update the TraceAppVersionValue from the Constants file!
+[assembly: AssemblyFileVersion("1.0.9.0")] // Please also update the TraceAppVersionValue from the Constants file!

--- a/LanguageWeaverProvider/Studio/TranslationProvider/TranslationProviderFactory.cs
+++ b/LanguageWeaverProvider/Studio/TranslationProvider/TranslationProviderFactory.cs
@@ -28,12 +28,7 @@ namespace LanguageWeaverProvider
 			var options = GetOptions(translationProviderState);
 			CredentialManager.GetCredentials(options, true, standaloneCredentials);
 
-			var validated = Service.ValidateToken(options);
-			if (validated)
-			{
-				CredentialManager.UpdateCredentials(credentialStore, options);
-			}
-
+			_ = Service.ValidateAndUpdateTokenAsync(options, () => CredentialManager.UpdateCredentials(credentialStore, options));
 			ApplicationInitializer.TranslationOptions[options.Id] = options;
 
 			return new TranslationProvider(options);

--- a/LanguageWeaverProvider/pluginpackage.manifest.xml
+++ b/LanguageWeaverProvider/pluginpackage.manifest.xml
@@ -5,7 +5,7 @@
 	<PlugInName>Language Weaver Provider</PlugInName>
 	<Description>Language Weaver Provider</Description>
 	
-	<Version>1.0.8.0</Version>
+	<Version>1.0.9.0</Version>
 	<RequiredProduct name="TradosStudio" minversion="17.2" maxversion="17.9" />
 
 	<Include>


### PR DESCRIPTION
- Updated `TranslationProvider` factory to call `ValidateAndUpdateTokenAsync` without awaiting
- Fire-and-forget token validation now updates credentials asynchronously